### PR TITLE
[Refactor] 페이지별 라우팅 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,37 +1,48 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import MainPage from './pages/MainPage';
-import CoursesPage from './pages/CoursesPage';
-import ProjectsPage from './pages/ProjectsPage';
-import LoginPage from './pages/LoginPage';
-import Header from './components/Header';
+import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+
 import Footer from './components/Footer';
-import FrontBeginnerPage from './pages/FrontBeginnerPage';
-import TeamProjectPage from './pages/TeamProjectPage';
+import Header from './components/Header';
 import BasicLearningPage from './pages/BasicLearningPage';
-import ToolPage from './pages/ToolPage';
-import GitPage from './pages/GitPage';
+import CoursesPage from './pages/CoursesPage';
+import LectureDetailPage from './pages/LectureDetailPage';
+import LectureListPage from './pages/LectureListPage';
+import LectureMainPage from './pages/LectureMainPage';
+import LoginPage from './pages/LoginPage';
+import MainPage from './pages/MainPage';
+import ProjectsPage from './pages/ProjectsPage';
 import SignupPage from './pages/SignupPage';
 
 function App() {
   return (
-    <BrowserRouter>
-      <Header />
-      <main style={{ flexGrow: 1 }}>
-        <Routes>
-          <Route path="/" element={<MainPage />} />
-          <Route path="/courses" element={<CoursesPage />} />
-          <Route path="/projects" element={<ProjectsPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/front/beginner" element={<FrontBeginnerPage />} />
-          <Route path="/front/beginner/team-project" element={<TeamProjectPage />} />
-          <Route path="/front/basic-learning" element={<BasicLearningPage />} />
-          <Route path="/front/basic/git" element={<GitPage />} />
-          <Route path="/front/basic/tool" element={<ToolPage />} />
-        </Routes>
-      </main>
-      <Footer />
-    </BrowserRouter>
+    <div className="flex flex-col min-h-screen">
+      <Router>
+        <Header />
+        <main className="flex-grow">
+          <Routes>
+            {/* 메인 */}
+            <Route path="/" element={<MainPage />} />
+
+            {/* Auth */}
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/login" element={<LoginPage />} />
+
+            {/* 단계별 학습 */}
+            <Route path="/courses" element={<CoursesPage />} />
+            <Route path="/courses/:job/:level" element={<LectureListPage />} />
+            <Route path="/courses/:job/:level/:lectureId" element={<LectureMainPage />} />
+            <Route path="/courses/:job/:level/:lectureId/detail" element={<LectureDetailPage />} />
+
+            {/* 기초 학습 */}
+            <Route path="/learning/basic" element={<BasicLearningPage />} />
+            <Route path="/learning/basic/:lectureId" element={<LectureDetailPage />} />
+
+            {/* 팀 프로젝트 */}
+            <Route path="/projects" element={<ProjectsPage />} />
+          </Routes>
+        </main>
+        <Footer />
+      </Router>
+    </div>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
 
             {/* Auth */}
             <Route path="/signup" element={<SignupPage />} />
-            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signin" element={<LoginPage />} />
 
             {/* 단계별 학습 */}
             <Route path="/courses" element={<CoursesPage />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,17 +2,45 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import logoIcon from '../assets/logo_icon.png';
+import { useLockModal } from '../hooks/useLockModal';
+import LockModal from './LockModal';
 
 function Header() {
   const navigate = useNavigate();
   const location = useLocation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
 
   const isActive = (path: string) => location.pathname === path;
 
   const toggleMenu = () => {
     setIsMenuOpen((prev) => !prev);
+  };
+
+  const handleRankingClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
+  };
+
+  const handleMyPageClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
+  };
+
+  const handleContactClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
+  };
+
+  const handleAccountSettingsClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
+  };
+
+  const handleProjectsClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
   };
 
   useEffect(() => {
@@ -67,7 +95,8 @@ function Header() {
               className={isActive('/projects') ? 'font-bold text-black' : 'font-medium text-[#555]'}
             >
               <button
-                onClick={() => navigate('/projects')}
+                // onClick={() => navigate('/projects')}
+                onClick={handleProjectsClick}
                 className="bg-none border-none text-lg px-3 py-2 cursor-pointer"
               >
                 프로젝트 모집
@@ -77,7 +106,7 @@ function Header() {
               className={isActive('/ranking') ? 'font-bold text-black' : 'font-medium text-[#555]'}
             >
               <button
-                onClick={() => navigate('/ranking')}
+                onClick={handleRankingClick}
                 className="bg-none border-none text-lg px-3 py-2 cursor-pointer"
               >
                 랭킹
@@ -90,7 +119,7 @@ function Header() {
         <div className="flex items-center gap-4">
           <button
             className="bg-white px-5 py-2 rounded-full text-[1.05rem] font-medium cursor-pointer flex items-center gap-1 text-black"
-            onClick={() => navigate('/login')}
+            onClick={() => navigate('/signin')}
           >
             로그인 <span className="text-base">〉</span>
           </button>
@@ -106,19 +135,19 @@ function Header() {
               <div className="absolute top-12 right-0 bg-white border border-[#ddd] rounded-lg shadow-lg flex flex-col py-2 z-50 min-w-[160px]">
                 <button
                   className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                  onClick={() => alert('계정설정')}
+                  onClick={handleAccountSettingsClick}
                 >
                   계정설정
                 </button>
                 <button
                   className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                  onClick={() => alert('문의하기')}
+                  onClick={handleContactClick}
                 >
                   문의하기
                 </button>
                 <button
                   className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                  onClick={() => navigate('/mypage')}
+                  onClick={handleMyPageClick}
                 >
                   마이페이지
                 </button>
@@ -133,6 +162,8 @@ function Header() {
           </div>
         </div>
       </div>
+
+      <LockModal isOpen={isLockModalOpen} onClose={closeLockModal} />
     </header>
   );
 }

--- a/src/components/LockModal.tsx
+++ b/src/components/LockModal.tsx
@@ -1,0 +1,30 @@
+interface LockModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const LockModal: React.FC<LockModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg px-14 py-8 max-w-md mx-4 text-center shadow-2">
+        <div className="text-6xl mb-4">🔒</div>
+        <h3 className="text-xl font-bold mb-4 text-gray-800">추후 제공 예정입니다</h3>
+        <p className="text-gray-600 mb-6">
+          해당 기능은 현재 개발 중입니다.
+          <br />
+          조금만 기다려주세요!
+        </p>
+        <button
+          onClick={onClose}
+          className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-6 rounded-lg transition-colors"
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LockModal;

--- a/src/global.css
+++ b/src/global.css
@@ -23,3 +23,7 @@ div,
 span {
   line-height: 1;
 }
+
+button {
+  cursor: pointer;
+}

--- a/src/hooks/useLockModal.ts
+++ b/src/hooks/useLockModal.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export const useLockModal = () => {
+  const [isLockModalOpen, setIsLockModalOpen] = useState(false);
+
+  const openLockModal = () => {
+    setIsLockModalOpen(true);
+  };
+
+  const closeLockModal = () => {
+    setIsLockModalOpen(false);
+  };
+
+  const handleLockedItemClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    openLockModal();
+  };
+
+  return {
+    isLockModalOpen,
+    openLockModal,
+    closeLockModal,
+    handleLockedItemClick,
+  };
+};

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -4,13 +4,26 @@ import { useNavigate } from 'react-router-dom';
 import Backend from '../assets/backend.png';
 import Designer from '../assets/designer.png';
 import Frontend from '../assets/frontend.png';
+import LockModal from '../components/LockModal';
+import { useLockModal } from '../hooks/useLockModal';
 
 function CoursesPage() {
   const [selectedTab, setSelectedTab] = useState('front');
   const navigate = useNavigate();
+  const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
 
   const handleBeginnerClick = () => {
     navigate('/front/beginner');
+  };
+
+  const handleBackendClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
+  };
+
+  const handleDesignerClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    handleLockedItemClick(e);
   };
 
   return (
@@ -38,7 +51,8 @@ function CoursesPage() {
           className={`bg-white border-2 ${
             selectedTab === 'back' ? 'border-[#007bff]' : 'border-transparent'
           } rounded-2xl p-5 w-[200px] cursor-pointer shadow-[0_4px_8px_rgba(0,0,0,0.05)] transition-all duration-200 ease-in-out text-center hover:-translate-y-1 hover:shadow-[0_6px_12px_rgba(0,0,0,0.1)]`}
-          onClick={() => setSelectedTab('back')}
+          // onClick={() => setSelectedTab('back')}
+          onClick={handleBackendClick}
         >
           <img src={Backend} alt="Back end" className="w-full rounded-xl mb-3" />
           <button
@@ -54,7 +68,8 @@ function CoursesPage() {
           className={`bg-white border-2 ${
             selectedTab === 'design' ? 'border-[#007bff]' : 'border-transparent'
           } rounded-2xl p-5 w-[200px] cursor-pointer shadow-[0_4px_8px_rgba(0,0,0,0.05)] transition-all duration-200 ease-in-out text-center hover:-translate-y-1 hover:shadow-[0_6px_12px_rgba(0,0,0,0.1)]`}
-          onClick={() => setSelectedTab('design')}
+          // onClick={() => setSelectedTab('design')}
+          onClick={handleDesignerClick}
         >
           <img src={Designer} alt="Designer" className="w-full rounded-xl mb-3" />
           <button
@@ -84,6 +99,7 @@ function CoursesPage() {
           </div>
         )}
       </div>
+      <LockModal isOpen={isLockModalOpen} onClose={closeLockModal} />
     </div>
   );
 }

--- a/src/pages/LectureDetailPage.tsx
+++ b/src/pages/LectureDetailPage.tsx
@@ -1,0 +1,17 @@
+import { useParams } from 'react-router-dom';
+
+import GitPage from './GitPage';
+import ToolPage from './ToolPage';
+
+const LectureDetailPage = () => {
+  const { lectureId } = useParams();
+
+  switch (lectureId) {
+    case 'git':
+      return <GitPage />;
+    case 'tool':
+      return <ToolPage />;
+  }
+};
+
+export default LectureDetailPage;

--- a/src/pages/LectureListPage.tsx
+++ b/src/pages/LectureListPage.tsx
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom';
+
+import FrontBeginnerPage from './FrontBeginnerPage';
+
+type LectureListParams = {
+  job: string;
+  level: string;
+};
+
+const LectureListPage = () => {
+  const { job, level } = useParams<LectureListParams>();
+
+  return <div>{job === 'fe' && level === 'beginner' && <FrontBeginnerPage />}</div>;
+};
+
+export default LectureListPage;

--- a/src/pages/LectureMainPage.tsx
+++ b/src/pages/LectureMainPage.tsx
@@ -1,0 +1,17 @@
+import { useParams } from 'react-router-dom';
+
+import TeamProjectPage from './TeamProjectPage';
+
+type LectureMainParams = {
+  job: string;
+  level: string;
+  lectureId?: string;
+};
+
+const LectureMainPage = () => {
+  const { job, level, lectureId } = useParams<LectureMainParams>();
+
+  return <div>{lectureId === 'team-project' && <TeamProjectPage />}</div>;
+};
+
+export default LectureMainPage;


### PR DESCRIPTION
## 요약

- 페이지별 라우팅 구조를 리팩터링하고, 강의 관련 페이지에 동적 라우트를 적용했습니다.
- 잠금 모달을 추가하고, 헤더와 단계별 학습 페이지에 적용했습니다.
<br>

## 작업 내용

- 기존 개별 라우트 삭제 및 통합
- 단계별 학습(Courses) 관련 동적 라우트 추가
  - /courses/:job/:level → LectureListPage
  - /courses/:job/:level/:lectureId → LectureMainPage
  - /courses/:job/:level/:lectureId/detail → LectureDetailPage
- 기초 학습 라우트에 동적 파라미터(:lectureId) 적용 → LectureDetailPage
- 새 페이지 컴포넌트 생성: LectureListPage, LectureMainPage, LectureDetailPage
- 동적 라우팅을 통해 강의 ID(이름) 및 직무/난이도에 따라 페이지 렌더링 구현
- 로그인 페이지 라우트를 login -> signin으로 변경
- 강의별 페이지 이동 및 렌더링 정상 확인 완료
- 잠금 모달 기능 추가
  - LockModal 컴포넌트 생성: 추후 제공 기능 안내
  - useLockModal 훅: 모달 열기/닫기 상태 관리 및 클릭 이벤트 처리
  - 헤더: 랭킹, 드롭다운 메뉴 클릭 시 모달 열림
  - 단계별 학습 페이지: 백엔드, 디자이너 클릭 시 모달 열림
<br>

## 참고 사항

- 현재 라우트 구조
````
{/* 메인 */}
<Route path="/" element={<MainPage />} /> // 메인 페이지

{/* Auth */}
<Route path="/signup" element={<SignupPage />} /> // 회원가입 페이지
<Route path="/signin" element={<LoginPage />} /> // 로그인 페이지

{/* 단계별 학습 */}
<Route path="/courses" element={<CoursesPage />} /> // 단계별 학습 페이지 (직무, 난이도 선택)
<Route path="/courses/:job/:level" element={<LectureListPage />} /> // 강의 목록 페이지 (MVP - FE 초급)
<Route path="/courses/:job/:level/:lectureId" element={<LectureMainPage />} /> // 강의 메인 페이지
<Route path="/courses/:job/:level/:lectureId/detail" element={<LectureDetailPage />} /> // 강의 상세 페이지

{/* 기초 학습 */}
<Route path="/learning/basic" element={<BasicLearningPage />} /> // 기초 학습 페이지
<Route path="/learning/basic/:lectureId" element={<LectureDetailPage />} /> // 강의 상세 페이지

{/* 팀 프로젝트 */}
<Route path="/projects" element={<ProjectsPage />} /> // 프로젝트 모집 페이지
````

- 잠금 모달 - 임의 디자인 적용
<img width="300" alt="image" src="https://github.com/user-attachments/assets/83df8686-d691-42ea-ab83-48fb5b4817a7" />

<br>

## 관련 이슈

- Closes #10 
