### PR TITLE
[Fix] 잘못된 경로 이동

### DIFF
--- a/src/pages/BasicLearningPage.tsx
+++ b/src/pages/BasicLearningPage.tsx
@@ -21,7 +21,7 @@ function BasicLearningPage() {
         </div>
         <div
           className="bg-gradient-to-br from-[#74ebd5] to-[#ACB6E5] w-[280px] p-[25px] rounded-[20px] shadow-[0_10px_20px_rgba(0,0,0,0.1)] transition-all duration-200 ease-in-out cursor-pointer text-left text-[#333] relative hover:-translate-y-[5px] hover:shadow-[0_12px_24px_rgba(0,0,0,0.15)]"
-          onClick={() => navigate('/front/basic/tool')}
+          onClick={() => navigate(ROUTES.BASIC_LEARNING.LECTURE_DETAIL('tool'))}
         >
           <h3 className="mb-2.5 text-[1.3rem]">Tool 설정법</h3>
           <p className="text-[0.95rem] text-[#222] mb-[15px]">개발 환경 셋업부터 Vite까지</p>

--- a/src/pages/BasicLearningPage.tsx
+++ b/src/pages/BasicLearningPage.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
+import { ROUTES } from '@/constants/routes';
+
 function BasicLearningPage() {
   const navigate = useNavigate();
 
@@ -9,7 +11,7 @@ function BasicLearningPage() {
       <div className="flex justify-center gap-10 flex-wrap">
         <div
           className="bg-gradient-to-br from-[#74ebd5] to-[#ACB6E5] w-[280px] p-[25px] rounded-[20px] shadow-[0_10px_20px_rgba(0,0,0,0.1)] transition-all duration-200 ease-in-out cursor-pointer text-left text-[#333] relative hover:-translate-y-[5px] hover:shadow-[0_12px_24px_rgba(0,0,0,0.15)]"
-          onClick={() => navigate('/front/basic/git')}
+          onClick={() => navigate(ROUTES.BASIC_LEARNING.LECTURE_DETAIL('git'))}
         >
           <h3 className="mb-2.5 text-[1.3rem]">깃 사용법</h3>
           <p className="text-[0.95rem] text-[#222] mb-[15px]">MVP 개발을 위한 버전 관리 시작하기</p>

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { ROUTES } from '@/constants/routes';
+
 import Backend from '../assets/backend.png';
 import Designer from '../assets/designer.png';
 import Frontend from '../assets/frontend.png';
@@ -13,7 +15,7 @@ function CoursesPage() {
   const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
 
   const handleBeginnerClick = () => {
-    navigate('/front/beginner');
+    navigate(ROUTES.COURSES.LECTURE_LIST('fe', 'beginner'));
   };
 
   const handleBackendClick = (e: React.MouseEvent) => {

--- a/src/pages/FrontBeginnerPage.tsx
+++ b/src/pages/FrontBeginnerPage.tsx
@@ -1,10 +1,12 @@
 import { useNavigate } from 'react-router-dom';
 
+import { ROUTES } from '@/constants/routes';
+
 function FrontBeginnerPage() {
   const navigate = useNavigate();
 
   const goToTeamProject = () => {
-    navigate('/front/beginner/team-project');
+    navigate(ROUTES.COURSES.LECTURE_MAIN('fe', 'beginner', 'team-project'));
   };
 
   return (


### PR DESCRIPTION
## 요약

- 잘못된 라우팅 경로로 인해 특정 학습 페이지 이동 시 빈 페이지가 표시되는 버그를 수정했습니다.
<br>

## 작업 내용

- 기초 학습 - 깃 사용법 경로를 /front/basic/git → /learning/basic/git 으로 수정
- 기초 학습 - Tool 설정법 경로를 /front/basic/tool → /learning/basic/tool 으로 수정
- 단계별 학습 - Frontend - 초급 경로를 /front/beginner → /courses/fe/beginner 으로 수정
- 단계별 학습 - Frontend - 초급 - 실전 Team Project 해보기 경로를 /front/beginner/team-project → /courses/fe/beginner/team-project 으로 수정
<br>

## 참고 사항

- [요구사항 명세서 - 라우트 정의](https://www.notion.so/1c9a586dfb0d80b6abc5dc1a6d1d7d23?source=copy_link)
- #10, #11
<br>

## 관련 이슈

- Closes #22 
