### PR TITLE
[Refactor] 라우트 경로 수정

### DIFF
--- a/src/pages/FrontBeginnerPage.tsx
+++ b/src/pages/FrontBeginnerPage.tsx
@@ -6,7 +6,7 @@ function FrontBeginnerPage() {
   const navigate = useNavigate();
 
   const goToTeamProject = () => {
-    navigate(ROUTES.COURSES.LECTURE_MAIN('fe', 'beginner', 'team-project'));
+    navigate(ROUTES.COURSES.LECTURE_MAIN('fe', 'intermediate', 'team-project'));
   };
 
   return (

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { ROUTES } from '@/constants/routes';
 
-function FrontBeginnerPage() {
+function FrontIntermediatePage() {
   const navigate = useNavigate();
 
   const goToTeamProject = () => {
@@ -31,4 +31,4 @@ function FrontBeginnerPage() {
   );
 }
 
-export default FrontBeginnerPage;
+export default FrontIntermediatePage;

--- a/src/pages/LectureListPage.tsx
+++ b/src/pages/LectureListPage.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 
-import FrontBeginnerPage from './FrontBeginnerPage';
+import FrontIntermediatePage from './FrontIntermediatePage';
 
 type LectureListParams = {
   job: string;
@@ -10,7 +10,7 @@ type LectureListParams = {
 const LectureListPage = () => {
   const { job, level } = useParams<LectureListParams>();
 
-  return <div>{job === 'fe' && level === 'intermediate' && <FrontBeginnerPage />}</div>;
+  return <div>{job === 'fe' && level === 'intermediate' && <FrontIntermediatePage />}</div>;
 };
 
 export default LectureListPage;

--- a/src/pages/LectureListPage.tsx
+++ b/src/pages/LectureListPage.tsx
@@ -10,7 +10,7 @@ type LectureListParams = {
 const LectureListPage = () => {
   const { job, level } = useParams<LectureListParams>();
 
-  return <div>{job === 'fe' && level === 'beginner' && <FrontBeginnerPage />}</div>;
+  return <div>{job === 'fe' && level === 'intermediate' && <FrontBeginnerPage />}</div>;
 };
 
 export default LectureListPage;

--- a/src/pages/LectureMainPage.tsx
+++ b/src/pages/LectureMainPage.tsx
@@ -11,7 +11,13 @@ type LectureMainParams = {
 const LectureMainPage = () => {
   const { job, level, lectureId } = useParams<LectureMainParams>();
 
-  return <div>{lectureId === 'team-project' && <TeamProjectPage />}</div>;
+  return (
+    <div>
+      {job === 'fe' && level === 'intermediate' && lectureId === 'team-project' && (
+        <TeamProjectPage />
+      )}
+    </div>
+  );
 };
 
 export default LectureMainPage;


### PR DESCRIPTION
## 요약

- MVP 난이도 변경(초급 -> 중급)에 따라 단계별 학습의 라우트 경로를 수정했습니다.
<br>

## 작업 내용

- 강의 선택 페이지: 라우트 경로 /beginner -> /intermediate로 수정
- '팀 프로젝트' 메인 페이지: 라우트 경로 /beginner/team-project -> /intermediate/team-project로 수정
- 기존 FrontBeginnerPage -> FrontIntermediatePage로 컴포넌트명 및 파일명 변경
- 기존 navigate 대응 여부 확인
<br>

## 관련 이슈

- Closes #25 
