### PR TITLE
[Feat] 강의 선택 페이지 제작 - FE 중급

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
     <div>
       <BrowserRouter>
         <Header />
-        <main className="flex-grow">
+        <main>
           <Router />
         </main>
         <Footer />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import Footer from './components/Footer';
 import Header from './components/Header';
 import Router from './router/router';
 
-function App() {
+const App = () => {
   return (
     <div>
       <BrowserRouter>
@@ -16,6 +16,6 @@ function App() {
       </BrowserRouter>
     </div>
   );
-}
+};
 
 export default App;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-function Footer() {
+const Footer = () => {
   return (
     <footer className="bg-white border-t-2 border-[#0059b3] text-center px-2.5 py-5 text-[#003366]">
       <div>© 2025 웹 개발 학습 플랫폼</div>
@@ -24,6 +24,6 @@ function Footer() {
       </div>
     </footer>
   );
-}
+};
 
 export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,9 +24,9 @@ const Header = () => {
     const path = location.pathname;
 
     if (path.startsWith('/courses/')) {
-      return '1.844rem';
+      return 'h-[1.844rem]';
     } else {
-      return '2.188rem';
+      return 'h-[2.188rem]';
     }
   };
 
@@ -89,7 +89,7 @@ const Header = () => {
   return (
     <>
       {/* 상단 여백 */}
-      <div className={`bg-gray-50 w-full h-[${getTopSpacerHeight()}]`}></div>
+      <div className={`bg-gray-50 w-full ${getTopSpacerHeight()}`}></div>
 
       {/* 헤더 */}
       <header

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { AiOutlineMenu } from 'react-icons/ai';
 import { HiOutlineUser } from 'react-icons/hi';
 import { TfiAngleRight } from 'react-icons/tfi';
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 
 import logo from '@/assets/logo.svg';
 import { NAV_ITEMS } from '@/constants/menuData';
@@ -14,9 +14,21 @@ import LockModal from './LockModal';
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showHeaderShadow, setShowHeaderShadow] = useState(false);
-
   const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const location = useLocation();
   const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
+
+  // 페이지별 상단 여백 높이 설정
+  const getTopSpacerHeight = () => {
+    const path = location.pathname;
+
+    if (path.startsWith('/courses/')) {
+      return '1.844rem';
+    } else {
+      return '2.188rem';
+    }
+  };
 
   const toggleMenu = () => {
     setIsMenuOpen((prev) => !prev);
@@ -77,7 +89,7 @@ const Header = () => {
   return (
     <>
       {/* 상단 여백 */}
-      <div className="bg-gray-50 w-full h-[2.188rem]"></div>
+      <div className={`bg-gray-50 w-full h-[${getTopSpacerHeight()}]`}></div>
 
       {/* 헤더 */}
       <header

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -15,6 +15,7 @@ import SettingsIcon from '@/assets/info-panel/settings.png';
 import TypewriterWithScreenIcon from '@/assets/info-panel/typewriter_with_screen.png';
 import WebIcon from '@/assets/info-panel/web.png';
 import WorkstationIcon from '@/assets/info-panel/workstation.png';
+import { JOB_TYPES } from '@/constants/jobTypes';
 import { ROUTES } from '@/constants/routes';
 import { useLockModal } from '@/hooks/useLockModal';
 
@@ -39,7 +40,7 @@ interface LevelItem {
 
 const panelContent: Record<InfoPanelProps['type'], { title: string; desc: DescItem[] }> = {
   fe: {
-    title: 'Frontend란?',
+    title: `${JOB_TYPES.FE}란?`,
     desc: [
       {
         icon: WorkstationIcon,
@@ -64,7 +65,7 @@ const panelContent: Record<InfoPanelProps['type'], { title: string; desc: DescIt
     ],
   },
   be: {
-    title: 'Backend란?',
+    title: `${JOB_TYPES.BE}란?`,
     desc: [
       {
         icon: SettingsIcon,
@@ -89,7 +90,7 @@ const panelContent: Record<InfoPanelProps['type'], { title: string; desc: DescIt
     ],
   },
   design: {
-    title: 'Designer란?',
+    title: `${JOB_TYPES.DESIGN}란?`,
     desc: [
       {
         icon: WebIcon,

--- a/src/components/LockModal.tsx
+++ b/src/components/LockModal.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { AnimatePresence, motion } from 'framer-motion';
 
 interface LockModalProps {
@@ -7,6 +9,20 @@ interface LockModalProps {
 }
 
 const LockModal = ({ isOpen, onClose, message }: LockModalProps) => {
+  // Enter 키로 모달 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
   return (
     <AnimatePresence>
       {isOpen && (

--- a/src/components/LockModal.tsx
+++ b/src/components/LockModal.tsx
@@ -6,7 +6,7 @@ interface LockModalProps {
   message?: string;
 }
 
-const LockModal: React.FC<LockModalProps> = ({ isOpen, onClose, message }) => {
+const LockModal = ({ isOpen, onClose, message }: LockModalProps) => {
   return (
     <AnimatePresence>
       {isOpen && (

--- a/src/constants/jobTypes.ts
+++ b/src/constants/jobTypes.ts
@@ -1,0 +1,6 @@
+export const JOB_TYPES = {
+  FE: 'Frontend',
+  BE: 'Backend',
+  DESIGN: 'Designer',
+  PLAN: 'Planner',
+} as const;

--- a/src/pages/BasicLearningPage.tsx
+++ b/src/pages/BasicLearningPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { ROUTES } from '@/constants/routes';
 
-function BasicLearningPage() {
+const BasicLearningPage = () => {
   const navigate = useNavigate();
 
   return (
@@ -32,6 +32,6 @@ function BasicLearningPage() {
       </div>
     </div>
   );
-}
+};
 
 export default BasicLearningPage;

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -12,7 +12,7 @@ import Frontend from '../assets/frontend.png';
 import LockModal from '../components/LockModal';
 import { useLockModal } from '../hooks/useLockModal';
 
-function CoursesPage() {
+const CoursesPage = () => {
   const [selectedTab, setSelectedTab] = useState<'fe' | 'be' | 'design' | null>(null);
   const [animatingTab, setAnimatingTab] = useState<'fe' | 'be' | 'design' | null>(null);
   const navigate = useNavigate();
@@ -96,9 +96,7 @@ function CoursesPage() {
           </button>
 
           <AnimatePresence>
-            {selectedTab === 'fe' && (
-              <InfoPanel type="fe" onClose={() => setSelectedTab(null)} />
-            )}
+            {selectedTab === 'fe' && <InfoPanel type="fe" onClose={() => setSelectedTab(null)} />}
           </AnimatePresence>
         </div>
 
@@ -126,9 +124,7 @@ function CoursesPage() {
           </button>
 
           <AnimatePresence>
-            {selectedTab === 'be' && (
-              <InfoPanel type="be" onClose={() => setSelectedTab(null)} />
-            )}
+            {selectedTab === 'be' && <InfoPanel type="be" onClose={() => setSelectedTab(null)} />}
           </AnimatePresence>
         </div>
 
@@ -170,6 +166,6 @@ function CoursesPage() {
       />
     </div>
   );
-}
+};
 
 export default CoursesPage;

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -4,12 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
 
 import InfoPanel from '@/components/InfoPanel';
-import { ROUTES } from '@/constants/routes';
 
 import Backend from '../assets/backend.png';
 import Designer from '../assets/designer.png';
 import Frontend from '../assets/frontend.png';
 import LockModal from '../components/LockModal';
+import { JOB_TYPES } from '../constants/jobTypes';
 import { useLockModal } from '../hooks/useLockModal';
 
 const CoursesPage = () => {
@@ -92,7 +92,7 @@ const CoursesPage = () => {
               selectedTab === 'fe' ? 'bg-[#007bff] text-white' : 'text-[#007bff]'
             }`}
           >
-            Front end
+            {JOB_TYPES.FE}
           </button>
 
           <AnimatePresence>
@@ -120,7 +120,7 @@ const CoursesPage = () => {
               selectedTab === 'be' ? 'bg-[#007bff] text-white' : 'text-[#007bff]'
             }`}
           >
-            Back end
+            {JOB_TYPES.BE}
           </button>
 
           <AnimatePresence>
@@ -148,7 +148,7 @@ const CoursesPage = () => {
               selectedTab === 'design' ? 'bg-[#007bff] text-white' : 'text-[#007bff]'
             }`}
           >
-            Designer
+            {JOB_TYPES.DESIGN}
           </button>
 
           <AnimatePresence>

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -9,6 +9,12 @@ interface OverviewItemProps {
   content: string;
 }
 
+// 강의 목록 아이템 타입
+interface LectureItemProps {
+  title: string;
+  locked?: boolean;
+}
+
 // 프로젝트 개요 아이템 컴포넌트
 const OverviewItem = ({ title, content }: OverviewItemProps) => {
   return (
@@ -22,6 +28,30 @@ const OverviewItem = ({ title, content }: OverviewItemProps) => {
   );
 };
 
+// 팀원 프로필 컴포넌트
+const CollaborationDots = () => {
+  const colors = ['bg-blue-400', 'bg-blue-200', 'bg-blue-300'];
+
+  return (
+    <div className="flex max-h-[6.193rem]">
+      {colors.map((color, idx) => (
+        <div className="flex w-[6.193rem] aspect-square bg-gray-80 rounded-full -ml-[1.509rem] first:ml-0 p-[0.516rem]">
+          <div key={idx} className={`${color} w-full h-full rounded-full`}></div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// 강의 목록 아이템 컴포넌트
+const LectureItem = ({ title, locked }: LectureItemProps) => {
+  return (
+    <li className="bg-gray-50 h-33 flex items-center justify-center rounded-2xl">
+      <span className="text-[1.908rem] leading-[1.16] tracking-[0.03em]">{title}</span>
+    </li>
+  );
+};
+
 const FrontIntermediatePage = () => {
   const navigate = useNavigate();
 
@@ -30,6 +60,13 @@ const FrontIntermediatePage = () => {
     { title: 'Team', content: 'hackplay' },
     { title: 'Projects', content: '개발하기' },
     { title: 'Goals', content: '달성 완료 (1/5)' },
+  ];
+
+  // 강의 목록 아이템 데이터
+  const lectureItems: LectureItemProps[] = [
+    { title: '프론트엔드 기초가 부족하다면?' },
+    { title: '아직 Git 사용법을 모른다면?' },
+    { title: '바로 Project 시작하기!' },
   ];
 
   const goToTeamProject = () => {
@@ -49,6 +86,7 @@ const FrontIntermediatePage = () => {
         함께 프로젝트를 진행하게 되어 기뻐요. 함께 멋진 결과물을 만들어봅시다!
       </p>
 
+      {/* 메인 */}
       <div className="mt-11 flex w-full gap-[1.875rem] h-[54.813rem]">
         {/* 프로젝트 정보 */}
         <div className="flex-[659]">
@@ -88,26 +126,35 @@ const FrontIntermediatePage = () => {
           </div>
         </div>
 
+        {/* 워크스페이스 */}
         <div className="flex-[829]">
-          <div className="card-box h-full">팀 프로젝트</div>
+          <div className="card-box h-full pt-15 pb-[4.063rem] px-15 flex flex-col items-center">
+            {/* 헤더 */}
+            <h3 className="font-[590] text-4xl leading-[1.17] tracking-[0.01em]">
+              Team Project Workspace
+            </h3>
+            <p className="mt-[0.813rem] mb-[2.688rem] font-[410] text-[1.75rem] leading-[1.18] tracking-[0.01em]">
+              당신의 프로젝트 팀과 원활하게 협업해 보세요!
+            </p>
+            <CollaborationDots />
+
+            {/* 강의 목록 */}
+            <ul className="mt-[2.994rem] w-full h-full flex flex-col justify-between">
+              {lectureItems.map((item, idx) => (
+                <LectureItem key={idx} title={item.title} />
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
 
-      {/* <div className="tab-wrapper">
-        <div className="level-tab level-intermediate locked">
-          front 기초 언어 (HTML/CSS/JS) 강의 - 추후 개발 🔒
-        </div>
-        <div
-          className="level-tab level-beginner active"
-          onClick={goToTeamProject}
-          style={{ cursor: 'pointer' }}
-        >
-          실전 Team Project 해보기 강의
-        </div>
+      {/* 푸터 */}
+      <div className="flex h-[2.438rem] mt-[3.813rem] mb-38">
+        <p className="text-2xl leading-[1] text-gray-600">
+          단순한 강의 시청이 아닌, 코드를 직접 작성하고 실시간 피드백을 통해 실력을 키워나갈 수
+          있습니다.
+        </p>
       </div>
-      <div className="tab-content">
-        <p>React로 실제 프론트 MVP를 만드는 실습 강의가 이곳에 제공될 예정입니다.</p>
-      </div> */}
     </div>
   );
 };

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -1,7 +1,9 @@
 import { AiOutlineCalendar } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
 
+import LockModal from '@/components/LockModal';
 import { ROUTES } from '@/constants/routes';
+import { useLockModal } from '@/hooks/useLockModal';
 
 // 프로젝트 개요 아이템 타입
 interface OverviewItemProps {
@@ -44,9 +46,12 @@ const CollaborationDots = () => {
 };
 
 // 강의 목록 아이템 컴포넌트
-const LectureItem = ({ title, locked }: LectureItemProps) => {
+const LectureItem = ({ title, onClick }: LectureItemProps & { onClick: () => void }) => {
   return (
-    <li className="bg-gray-50 h-33 flex items-center justify-center rounded-2xl">
+    <li
+      onClick={onClick}
+      className="bg-gray-50 h-33 flex items-center justify-center rounded-2xl cursor-pointer"
+    >
       <span className="text-[1.908rem] leading-[1.16] tracking-[0.03em]">{title}</span>
     </li>
   );
@@ -54,6 +59,7 @@ const LectureItem = ({ title, locked }: LectureItemProps) => {
 
 const FrontIntermediatePage = () => {
   const navigate = useNavigate();
+  const { isLockModalOpen, openLockModal, closeLockModal } = useLockModal(); // 잠금 모달 훅
 
   // 프로젝트 개요 아이템 데이터
   const overviewItems: OverviewItemProps[] = [
@@ -64,7 +70,7 @@ const FrontIntermediatePage = () => {
 
   // 강의 목록 아이템 데이터
   const lectureItems: LectureItemProps[] = [
-    { title: '프론트엔드 심화 언어를 배우고 싶다면?' },
+    { title: '프론트엔드 심화 언어를 배우고 싶다면?', locked: true },
     { title: '바로 Project 시작하기!' },
   ];
 
@@ -140,7 +146,11 @@ const FrontIntermediatePage = () => {
             {/* 강의 목록 */}
             <ul className="mt-[2.994rem] w-full h-full flex flex-col gap-[2.438rem] justify-center">
               {lectureItems.map((item, idx) => (
-                <LectureItem key={idx} title={item.title} />
+                <LectureItem
+                  key={idx}
+                  title={item.title}
+                  onClick={item.locked ? openLockModal : goToTeamProject}
+                />
               ))}
             </ul>
           </div>
@@ -154,6 +164,13 @@ const FrontIntermediatePage = () => {
           있습니다.
         </p>
       </div>
+
+      {/* 잠금 모달 */}
+      <LockModal
+        isOpen={isLockModalOpen}
+        onClose={closeLockModal}
+        message="이 강의는 현재 잠겨 있습니다."
+      />
     </div>
   );
 };

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -1,9 +1,21 @@
 import { AiOutlineCalendar } from 'react-icons/ai';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import LockModal from '@/components/LockModal';
+import { JOB_TYPES } from '@/constants/jobTypes';
 import { ROUTES } from '@/constants/routes';
 import { useLockModal } from '@/hooks/useLockModal';
+
+// 라우트 경로에 따른 포지션 매핑 함수
+const getPositionByRoute = (job?: string): string => {
+  const jobToPosition: Record<string, string> = {
+    fe: `${JOB_TYPES.FE} Developer`,
+    be: `${JOB_TYPES.BE} Developer`,
+    design: JOB_TYPES.DESIGN,
+  };
+
+  return jobToPosition[job ?? ''];
+};
 
 // 프로젝트 개요 아이템 타입
 interface OverviewItemProps {
@@ -65,6 +77,8 @@ const LectureItem = ({ title, locked, onClick }: LectureItemProps & { onClick: (
 
 const FrontIntermediatePage = () => {
   const navigate = useNavigate();
+  const { job } = useParams();
+  const position = getPositionByRoute(job);
   const { isLockModalOpen, openLockModal, closeLockModal } = useLockModal(); // 잠금 모달 훅
 
   // 프로젝트 개요 아이템 데이터
@@ -108,8 +122,8 @@ const FrontIntermediatePage = () => {
               <span className="font-[680]">홍길동</span>님의 포지션
             </h3>
             <div className="mt-[0.813rem] max-w-[23.438rem] py-[1.35rem] px-[4.438rem] rounded-5xl bg-linear-90 blue-gradient from-19% to-68%">
-              <span className="font-[590] text-[1.75rem] leading-[1.18] text-white">
-                Backend Developer
+              <span className="font-[590] text-[1.75rem] leading-[1.18] text-white whitespace-nowrap">
+                {position}
               </span>
             </div>
 

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -64,8 +64,7 @@ const FrontIntermediatePage = () => {
 
   // 강의 목록 아이템 데이터
   const lectureItems: LectureItemProps[] = [
-    { title: '프론트엔드 기초가 부족하다면?' },
-    { title: '아직 Git 사용법을 모른다면?' },
+    { title: '프론트엔드 심화 언어를 배우고 싶다면?' },
     { title: '바로 Project 시작하기!' },
   ];
 
@@ -139,7 +138,7 @@ const FrontIntermediatePage = () => {
             <CollaborationDots />
 
             {/* 강의 목록 */}
-            <ul className="mt-[2.994rem] w-full h-full flex flex-col justify-between">
+            <ul className="mt-[2.994rem] w-full h-full flex flex-col gap-[2.438rem] justify-center">
               {lectureItems.map((item, idx) => (
                 <LectureItem key={idx} title={item.title} />
               ))}

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -22,7 +22,7 @@ const OverviewItem = ({ title, content }: OverviewItemProps) => {
   );
 };
 
-function FrontIntermediatePage() {
+const FrontIntermediatePage = () => {
   const navigate = useNavigate();
 
   // 프로젝트 개요 아이템 데이터
@@ -110,6 +110,6 @@ function FrontIntermediatePage() {
       </div> */}
     </div>
   );
-}
+};
 
 export default FrontIntermediatePage;

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -1,18 +1,99 @@
+import { AiOutlineCalendar } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
 
 import { ROUTES } from '@/constants/routes';
 
+// 프로젝트 개요 아이템 타입
+interface OverviewItemProps {
+  title: string;
+  content: string;
+}
+
+// 프로젝트 개요 아이템 컴포넌트
+const OverviewItem = ({ title, content }: OverviewItemProps) => {
+  return (
+    <div className="flex flex-col items-center w-22 max-w-22 h-full justify-between">
+      <div className="w-[4.065rem] aspect-square rounded-full bg-gray-200" />
+      <div className="flex flex-col items-center h-full max-h-[2.625rem] justify-between">
+        <div className="text-[1.2rem] leading-[1.15] font-[590]">{title}</div>
+        <div className="text-[0.975rem] leading-[1.15] text-gray-650">{content}</div>
+      </div>
+    </div>
+  );
+};
+
 function FrontIntermediatePage() {
   const navigate = useNavigate();
+
+  // 프로젝트 개요 아이템 데이터
+  const overviewItems: OverviewItemProps[] = [
+    { title: 'Team', content: 'hackplay' },
+    { title: 'Projects', content: '개발하기' },
+    { title: 'Goals', content: '달성 완료 (1/5)' },
+  ];
 
   const goToTeamProject = () => {
     navigate(ROUTES.COURSES.LECTURE_MAIN('fe', 'intermediate', 'team-project'));
   };
 
   return (
-    <div className="page-container">
-      <h2>2-1-1. 초급 학습 페이지</h2>
-      <div className="tab-wrapper">
+    <div className="page-container pt-[4.344rem]">
+      {/* 헤더 */}
+      <div className="w-26 aspect-square rounded-full bg-white shadow-7 flex items-center justify-center p-4">
+        <img src={`${import.meta.env.BASE_URL}favicon/apple-touch-icon.png`} alt="아이콘" />
+      </div>
+      <h2 className="mt-9 text-[4.375rem] tracking-[0.02em] leading-[1.17] mb-[0.313rem]">
+        <span className="font-[590]">홍길동</span>님, 환영합니다! 👋
+      </h2>
+      <p className="font-[410] text-[2rem] leading-[1.625] tracking-[0.04em]">
+        함께 프로젝트를 진행하게 되어 기뻐요. 함께 멋진 결과물을 만들어봅시다!
+      </p>
+
+      <div className="mt-11 flex w-full gap-[1.875rem] h-[54.813rem]">
+        {/* 프로젝트 정보 */}
+        <div className="flex-[659]">
+          <div className="flex flex-col card-box h-full py-15 px-[3.313rem] items-center">
+            {/* 포지션 */}
+            <div className="rounded-full w-[8.563rem] aspect-square bg-linear-153 blue-gradient to-82%"></div>
+            <h3 className="mt-[2.375rem] font-[590] text-4xl leading-[1.17] tracking-[0.02em]">
+              <span className="font-[680]">홍길동</span>님의 포지션
+            </h3>
+            <div className="mt-[0.813rem] max-w-[23.438rem] py-[1.35rem] px-[4.438rem] rounded-5xl bg-linear-90 blue-gradient from-19% to-68%">
+              <span className="font-[590] text-[1.75rem] leading-[1.18] text-white">
+                Backend Developer
+              </span>
+            </div>
+
+            {/* 프로젝트 시작일 */}
+            <div className="mt-[2.676rem] bg-gray-50 w-full rounded-2xl px-[8.125rem] py-[1.875rem]">
+              <div className="flex flex-col items-center">
+                <div className="max-w-[4.688rem] aspect-square bg-blue-100/80 rounded-full p-5">
+                  <AiOutlineCalendar className="w-[2.188rem] h-[2.188rem] text-blue-400 stroke-15" />
+                </div>
+                <p className="mt-[1.625rem] text-[1.625rem] leading-[1.15] tracking-[0.02em]">
+                  프로젝트 시작일
+                </p>
+                <p className="mt-[0.688rem] font-[680] text-[2.411rem] leading-[1.17] tracking-[0.03em] text-blue-400">
+                  2025년 05월 17일
+                </p>
+              </div>
+            </div>
+
+            {/* 프로젝트 개요 */}
+            <div className="mt-auto flex w-full max-w-[26.813rem] h-full max-h-[7.625rem] items-center justify-between">
+              {overviewItems.map((item, idx) => (
+                <OverviewItem key={idx} title={item.title} content={item.content} />
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-[829]">
+          <div className="card-box h-full">팀 프로젝트</div>
+        </div>
+      </div>
+
+      {/* <div className="tab-wrapper">
         <div className="level-tab level-intermediate locked">
           front 기초 언어 (HTML/CSS/JS) 강의 - 추후 개발 🔒
         </div>
@@ -26,7 +107,7 @@ function FrontIntermediatePage() {
       </div>
       <div className="tab-content">
         <p>React로 실제 프론트 MVP를 만드는 실습 강의가 이곳에 제공될 예정입니다.</p>
-      </div>
+      </div> */}
     </div>
   );
 }

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -46,13 +46,19 @@ const CollaborationDots = () => {
 };
 
 // 강의 목록 아이템 컴포넌트
-const LectureItem = ({ title, onClick }: LectureItemProps & { onClick: () => void }) => {
+const LectureItem = ({ title, locked, onClick }: LectureItemProps & { onClick: () => void }) => {
   return (
     <li
       onClick={onClick}
       className="bg-gray-50 h-33 flex items-center justify-center rounded-2xl cursor-pointer"
     >
       <span className="text-[1.908rem] leading-[1.16] tracking-[0.03em]">{title}</span>
+      {/* 준비중 배지 */}
+      {locked && (
+        <span className="ml-1.5 bg-blue-100 rounded-sm text-blue-450 inline-flex items-center px-2.5 py-1.5 text-lg leading-[1.13] tracking-tight font-bold">
+          준비중
+        </span>
+      )}
     </li>
   );
 };
@@ -149,6 +155,7 @@ const FrontIntermediatePage = () => {
                 <LectureItem
                   key={idx}
                   title={item.title}
+                  locked={item.locked}
                   onClick={item.locked ? openLockModal : goToTeamProject}
                 />
               ))}

--- a/src/pages/GitPage.tsx
+++ b/src/pages/GitPage.tsx
@@ -1,4 +1,4 @@
-function GitPage() {
+const GitPage = () => {
   return (
     <div className="page-container">
       <h2>깃 사용법 - MVP 개발</h2>
@@ -9,6 +9,6 @@ function GitPage() {
       </ul>
     </div>
   );
-}
+};
 
 export default GitPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import Mockup from '../assets/mockup.jpg';
 
-function MainPage() {
+const MainPage = () => {
   return (
     <div className="w-full mx-auto pt-16 sm:pt-20 md:pt-24 lg:pt-28 xl:pt-[8.125rem] text-center px-4 sm:px-6 md:px-8 lg: px-10 xl:px-[12.375rem]">
       <header>
@@ -38,6 +38,6 @@ function MainPage() {
       </section>
     </div>
   );
-}
+};
 
 export default MainPage;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,5 +1,4 @@
-
-function ProjectsPage() {
+const ProjectsPage = () => {
   return (
     <div className="page-container">
       <h2>프로젝트 모집 - 추후 개발 🔒 </h2>
@@ -7,6 +6,6 @@ function ProjectsPage() {
       <button className="basic-button">팀 만들기</button>
     </div>
   );
-}
+};
 
 export default ProjectsPage;

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -4,6 +4,7 @@ import { TbEye, TbEyeOff } from 'react-icons/tb';
 import { useNavigate } from 'react-router-dom';
 
 import { axiosInstance } from '@/api/axios';
+import { JOB_TYPES } from '@/constants/jobTypes';
 import { ROUTES } from '@/constants/routes';
 
 type FormValues = {
@@ -192,8 +193,8 @@ const SignupPage = () => {
             <option value="">직무 선택</option>
             <option value="PLAN">기획</option>
             <option value="DESIGN">디자인</option>
-            <option value="FRONT">Frontend</option>
-            <option value="BACK">Backend</option>
+            <option value="FRONT">{JOB_TYPES.FE}</option>
+            <option value="BACK">{JOB_TYPES.BE}</option>
           </select>
           {errors.role && <p className="text-red-500 text-sm mt-1">{errors.role.message}</p>}
 

--- a/src/pages/TeamProjectPage.tsx
+++ b/src/pages/TeamProjectPage.tsx
@@ -1,4 +1,4 @@
-function TeamProjectPage() {
+const TeamProjectPage = () => {
   // 임시 진도 데이터 (나중에 상태 기반으로 확장 가능)
   const completedUnits = 2;
   const totalUnits = 5;
@@ -114,6 +114,6 @@ function TeamProjectPage() {
       </div>
     </div>
   );
-}
+};
 
 export default TeamProjectPage;

--- a/src/pages/ToolPage.tsx
+++ b/src/pages/ToolPage.tsx
@@ -1,4 +1,4 @@
-function ToolPage() {
+const ToolPage = () => {
   return (
     <div className="page-container">
       <h2>툴 설정법 - MVP 개발</h2>
@@ -33,6 +33,6 @@ function ToolPage() {
       </div>
     </div>
   );
-}
+};
 
 export default ToolPage;

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,6 +54,7 @@
   --shadow-5: 0px 10px 19.9px 0px rgba(0, 0, 0, 0.28);
   --shadow-6: 1px 1px 50px 0px rgba(0, 0, 0, 0.4);
   --shadow-7: 1px 1px 20px -9px rgba(0, 0, 0, 0.4);
+  --shadow-8: 1px 1px 30px -9px rgba(0, 0, 0, 0.4);
 
   /** z-index 계층 구조 **/
 
@@ -83,4 +84,8 @@
 
 .basic-button {
   @apply bg-[#0059b3] text-white border-none px-5 py-2.5 mt-5 text-base cursor-pointer rounded-[5px] hover:bg-[#004080];
+}
+
+.card-box {
+  @apply rounded-2xl bg-white shadow-8;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,6 +53,7 @@
   --shadow-4: 0px 2px 2px 0px rgba(0, 0, 0, 0.1);
   --shadow-5: 0px 10px 19.9px 0px rgba(0, 0, 0, 0.28);
   --shadow-6: 1px 1px 50px 0px rgba(0, 0, 0, 0.4);
+  --shadow-7: 1px 1px 20px -9px rgba(0, 0, 0, 0.4);
 
   /** z-index 계층 구조 **/
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -77,7 +77,7 @@
 }
 
 .page-container {
-  @apply max-w-[95rem] mx-auto text-center;
+  @apply max-w-[95rem] mx-auto text-center flex flex-col items-center;
 }
 
 .basic-button {

--- a/src/styles.css
+++ b/src/styles.css
@@ -25,6 +25,7 @@
   --radius-2xl: 1.25rem; /* 20px */
   --radius-3xl: 1.844rem; /* 29.5px */
   --radius-4xl: 2.281rem; /* 36.5px */
+  --radius-5xl: 2.604rem; /* 41.67px */
 
   /** Colors **/
   --color-blue-100: #cddefe;
@@ -88,4 +89,8 @@
 
 .card-box {
   @apply rounded-2xl bg-white shadow-8;
+}
+
+.blue-gradient {
+  @apply from-blue-400 to-blue-300;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,6 +36,7 @@
   --color-blue-500: #075080;
 
   --color-gray-50: #fafafa;
+  --color-gray-80: #f6f6f6;
   --color-gray-100: #f4f4f4;
   --color-gray-200: #d9d9d9;
   --color-gray-300: #c0c0c0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,6 +42,7 @@
   --color-gray-400: #a8a8a8;
   --color-gray-500: #939393;
   --color-gray-600: #888888;
+  --color-gray-650: #474747;
   --color-gray-700: #363636;
 
   --color-white: #ffffff;

--- a/src/styles.css
+++ b/src/styles.css
@@ -77,7 +77,7 @@
 }
 
 .page-container {
-  @apply max-w-[600px] mx-auto my-[50px] p-[30px] border-2 border-[#0059b3] rounded-[10px] text-center;
+  @apply max-w-[95rem] mx-auto text-center;
 }
 
 .basic-button {


### PR DESCRIPTION
## 요약

- `Frontend` → `중급` 단계를 선택했을 때 진입하는 **강의 선택 페이지**를 제작했습니다.
<br>

## 작업 내용

#### 기능 구현

* FE -> 중급 단계의 강의 선택 페이지 UI 구현 (FrontIntermediatePage.tsx)
* 사용자 포지션 (좌측 박스 상단)
  *  URL을 기반으로 포지션 이름 렌더링
* 프로젝트 개요 아이템 - 좌측 박스 하단
  * 인터페이스 정의
  * 컴포넌트 분리하여 구현
  * 데이터 하드코딩
* 팀원 프로필 컴포넌트 - 우측 박스 중앙
  * 컴포넌트 분리하여 구현
* 강의 목록 아이템 - 우측 박스 하단
  * 인터페이스 정의
  * 컴포넌트 분리하여 구현
  * 데이터 하드코딩 - 강의 2개 표시
  * `프론트엔드 심화 언어를 배우고 싶다면?` -> 강의 제목 우측에 준비중 배지 표시, 클릭 시 잠금 모달 표시
  * `바로 Project 시작하기!` -> 클릭 시 해당 강의 메인 페이지로 이동
* 잠금 모달 Enter 키로도 닫히도록 개선
* 페이지 새로고침 및 브라우저 뒤로 가기 시 **Frontend → 중급 상태 유지** 확인

#### 스타일 및 디자인

* 모든 페이지에 대해 최대 너비 `1520px`로 조정
* 새로운 그림자, radius, 회색 색상 변수 추가
  * `--shadow-7`, `--shadow-8`
  * `--radius-5xl`
  * `--color-gray-650`, `--color-gray-80`
* `card-box`, `blue-gradient` 스타일 클래스 추가
* 강의 개수에 따라 유연하게 디자인
* 직무명 상수 `JOB_TYPES` 추가 및 기존 하드코딩 제거

#### 리팩터링

* 헤더 상단 여백 높이 설정 기능 추가 및 페이지별로 적용
* 함수형 컴포넌트로 전체 변경하여 일관성 확보
<br>

## 참고 사항

- 기본 UI
<img width="5757" alt="image" src="https://github.com/user-attachments/assets/b0ec5fc4-7d9f-4057-b05c-c3370c40f5c6" />

- 잠금 강의 클릭 시 모달 표시
<img width="5757" alt="image" src="https://github.com/user-attachments/assets/ae734db0-df2c-4bb2-85f5-0fdd645fbc05" />

<br>

## 관련 이슈

- Closes #28 
