### PR TITLE
[Feat] 회원가입 시 이메일 인증 로직 추가

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -38,6 +38,9 @@ body {
 
 button {
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 button:disabled {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { TbEye, TbEyeOff } from 'react-icons/tb';
 import { useNavigate } from 'react-router-dom';
@@ -23,6 +23,11 @@ const SignupPage = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false); // 이메일 인증 중 상태
+  const [isCodeSent, setIsCodeSent] = useState(true); // 인증코드 전송 완료 여부
+  const [isCodeVerified, setIsCodeVerified] = useState(false); // 인증코드 확인 완료 여부
+  const [isVerifyingCode, setIsVerifyingCode] = useState(false); // 인증코드 확인 중 상태
+  const [verificationCode, setVerificationCode] = useState(''); // 인증코드
+  const [verificationCodeError, setVerificationCodeError] = useState(''); // 인증코드 에러
 
   const {
     register,
@@ -39,6 +44,28 @@ const SignupPage = () => {
   const email = watch('email');
 
   const canSubmit = isValid;
+
+  // 인증코드 검증 (영숫자 이외 문자, 6자리)
+  useEffect(() => {
+    if (!isCodeSent || isCodeVerified || !verificationCode) {
+      return;
+    }
+
+    // 영숫자 이외 문자 체크
+    if (/[^a-zA-Z0-9]/.test(verificationCode)) {
+      setVerificationCodeError('인증코드는 영문자와 숫자만 입력할 수 있습니다.');
+      return;
+    }
+
+    // 6자리 검증
+    if (!/^[a-zA-Z0-9]{6}$/.test(verificationCode)) {
+      setVerificationCodeError('인증코드는 6자리 영숫자입니다.');
+      return;
+    }
+
+    // 검증 통과 시 에러 초기화
+    setVerificationCodeError('');
+  }, [verificationCode, isCodeSent, isCodeVerified]);
 
   // 이메일 인증 처리 함수
   const handleEmailVerification = async () => {
@@ -61,6 +88,10 @@ const SignupPage = () => {
       if (checkResponse.data.data === 'N') {
         await axiosInstance.post('/v1/email/send', { email });
         alert('인증코드가 전송되었습니다. 이메일을 확인해주세요.');
+        setIsCodeSent(true);
+        setIsCodeVerified(false); // 새로운 인증코드 전송 시 인증 상태 초기화
+        setVerificationCode(''); // 인증코드 초기화
+        setVerificationCodeError(''); // 에러 초기화
       }
     } catch (error: any) {
       if (error.response) {
@@ -70,6 +101,41 @@ const SignupPage = () => {
       }
     } finally {
       setIsVerifying(false);
+    }
+  };
+
+  // 인증코드 확인 함수
+  const handleVerifyCode = async () => {
+    // 에러가 있으면 진행하지 않음
+    if (verificationCodeError) {
+      return;
+    }
+
+    if (!email) {
+      alert('이메일을 먼저 입력해주세요.');
+      return;
+    }
+
+    setIsVerifyingCode(true);
+    try {
+      // TODO: 인증코드 확인 API 호출
+      // const response = await axiosInstance.post('/v1/email/verify', { email, code: verificationCode });
+      // 임시로 성공 처리 (실제 API 연동 시 주석 해제)
+      await new Promise((resolve) => setTimeout(resolve, 500)); // 임시 딜레이
+      setIsCodeVerified(true);
+      setVerificationCodeError('');
+      alert('인증이 완료되었습니다.');
+    } catch (error: any) {
+      if (error.response) {
+        const errorMessage = error.response.data.message || '인증코드가 올바르지 않습니다.';
+        setVerificationCodeError(errorMessage);
+        alert(`인증 실패: ${errorMessage}`);
+      } else {
+        setVerificationCodeError('인증코드 확인 중 오류가 발생했습니다.');
+        alert('인증코드 확인 중 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsVerifyingCode(false);
     }
   };
 
@@ -112,7 +178,7 @@ const SignupPage = () => {
                 type="button"
                 disabled={!email || !!errors.email || isVerifying}
                 onClick={handleEmailVerification}
-                className={`font-semibold text-lg whitespace-nowrap px-4 rounded-lg transition-colors ${
+                className={`font-semibold text-lg whitespace-nowrap w-29 rounded-lg transition-colors ${
                   !email || errors.email || isVerifying
                     ? 'cursor-not-allowed bg-gray-150 text-gray-600'
                     : 'bg-blue-600 text-white hover:bg-blue-700'
@@ -123,6 +189,50 @@ const SignupPage = () => {
             </div>
             {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>}
           </div>
+
+          {/* 인증코드 입력 */}
+          {isCodeSent && (
+            <div className="flex flex-col">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  placeholder="인증코드 (6자리)"
+                  maxLength={6}
+                  value={verificationCode}
+                  disabled={isCodeVerified}
+                  onChange={(e) => {
+                    setVerificationCode(e.target.value);
+                  }}
+                  className={`w-full px-3 py-3 border rounded-lg bg-[#fefefe] text-base focus:outline-none focus:ring-2 focus:ring-[#0070f3]/30 focus:border-[#0070f3] ${
+                    isCodeVerified ? 'border-green-500 bg-green-50' : 'border-gray-300'
+                  } ${isCodeVerified ? 'cursor-not-allowed' : ''}`}
+                />
+                <button
+                  type="button"
+                  disabled={
+                    !verificationCode ||
+                    !!verificationCodeError ||
+                    isVerifyingCode ||
+                    isCodeVerified
+                  }
+                  onClick={handleVerifyCode}
+                  className={`font-semibold text-lg whitespace-nowrap w-29 rounded-lg transition-colors ${
+                    !verificationCode || verificationCodeError || isVerifyingCode || isCodeVerified
+                      ? 'cursor-not-allowed bg-gray-150 text-gray-600'
+                      : 'bg-blue-600 text-white hover:bg-blue-700'
+                  }`}
+                >
+                  {isCodeVerified ? '인증완료' : isVerifyingCode ? '확인 중...' : '확인'}
+                </button>
+              </div>
+              {verificationCodeError && (
+                <p className="text-red-500 text-sm mt-1">{verificationCodeError}</p>
+              )}
+              {isCodeVerified && (
+                <p className="text-green-600 text-sm mt-1">✓ 이메일 인증이 완료되었습니다.</p>
+              )}
+            </div>
+          )}
 
           {/* 닉네임 */}
           <div className="relative flex flex-col">

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -23,7 +23,7 @@ const SignupPage = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false); // 이메일 인증 중 상태
-  const [isCodeSent, setIsCodeSent] = useState(true); // 인증코드 전송 완료 여부
+  const [isCodeSent, setIsCodeSent] = useState(false); // 인증코드 전송 완료 여부
   const [isCodeVerified, setIsCodeVerified] = useState(false); // 인증코드 확인 완료 여부
   const [isVerifyingCode, setIsVerifyingCode] = useState(false); // 인증코드 확인 중 상태
   const [verificationCode, setVerificationCode] = useState(''); // 인증코드
@@ -118,13 +118,16 @@ const SignupPage = () => {
 
     setIsVerifyingCode(true);
     try {
-      // TODO: 인증코드 확인 API 호출
-      // const response = await axiosInstance.post('/v1/email/verify', { email, code: verificationCode });
-      // 임시로 성공 처리 (실제 API 연동 시 주석 해제)
-      await new Promise((resolve) => setTimeout(resolve, 500)); // 임시 딜레이
-      setIsCodeVerified(true);
-      setVerificationCodeError('');
-      alert('인증이 완료되었습니다.');
+      const response = await axiosInstance.post('/v1/email/verify', {
+        email,
+        verifyCode: verificationCode,
+      });
+
+      if (response.data.code === 200) {
+        setIsCodeVerified(true);
+        setVerificationCodeError('');
+        alert('인증이 완료되었습니다.');
+      }
     } catch (error: any) {
       if (error.response) {
         const errorMessage = error.response.data.message || '인증코드가 올바르지 않습니다.';

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -35,6 +35,7 @@ const SignupPage = () => {
   });
 
   const password = watch('password');
+  const email = watch('email');
 
   const canSubmit = isValid;
 
@@ -75,7 +76,10 @@ const SignupPage = () => {
               />
               <button
                 type="button"
-                className="bg-blue-600 text-white font-semibold text-lg whitespace-nowrap px-4 rounded-lg transition-colors hover:bg-blue-700"
+                disabled={!email || !!errors.email}
+                className={`bg-blue-600 text-white font-semibold text-lg whitespace-nowrap px-4 rounded-lg transition-colors ${
+                  !email || errors.email ? 'cursor-not-allowed' : 'hover:bg-blue-700'
+                }`}
               >
                 인증하기
               </button>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -165,6 +165,7 @@ const SignupPage = () => {
               <input
                 type="email"
                 placeholder="이메일"
+                disabled={isCodeVerified}
                 {...register('email', {
                   required: '이메일을 입력해주세요',
                   pattern: {
@@ -172,14 +173,16 @@ const SignupPage = () => {
                     message: '올바른 이메일 형식이 아닙니다.',
                   },
                 })}
-                className="w-full px-3 py-3 border border-gray-300 rounded-lg bg-[#fefefe] text-base focus:outline-none focus:ring-2 focus:ring-[#0070f3]/30 focus:border-[#0070f3]"
+                className={`w-full px-3 py-3 border border-gray-300 rounded-lg bg-[#fefefe] text-base focus:outline-none focus:ring-2 focus:ring-[#0070f3]/30 focus:border-[#0070f3] ${
+                  isCodeVerified ? 'cursor-not-allowed bg-gray-80' : ''
+                }`}
               />
               <button
                 type="button"
-                disabled={!email || !!errors.email || isVerifying}
+                disabled={!email || !!errors.email || isVerifying || isCodeVerified}
                 onClick={handleEmailVerification}
                 className={`font-semibold text-lg whitespace-nowrap w-29 rounded-lg transition-colors ${
-                  !email || errors.email || isVerifying
+                  !email || errors.email || isVerifying || isCodeVerified
                     ? 'cursor-not-allowed bg-gray-150 text-gray-600'
                     : 'bg-blue-600 text-white hover:bg-blue-700'
                 }`}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -43,7 +43,7 @@ const SignupPage = () => {
   const password = watch('password');
   const email = watch('email');
 
-  const canSubmit = isValid;
+  const canSubmit = isValid && isCodeVerified;
 
   // 인증코드 검증 (영숫자 이외 문자, 6자리)
   useEffect(() => {
@@ -383,8 +383,10 @@ const SignupPage = () => {
           <button
             type="submit"
             disabled={!canSubmit}
-            className={`bg-blue-600 text-white font-semibold text-lg py-3 rounded-lg transition-colors ${
-              canSubmit ? 'hover:bg-blue-700' : 'cursor-not-allowed'
+            className={`font-semibold text-lg py-3 rounded-lg transition-colors ${
+              canSubmit
+                ? 'bg-blue-600 text-white hover:bg-blue-700'
+                : 'cursor-not-allowed bg-gray-150 text-gray-600'
             }`}
           >
             회원가입

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -59,20 +59,27 @@ const SignupPage = () => {
 
         <form className="flex flex-col gap-5" onSubmit={handleSubmit(onSubmit)}>
           {/* 이메일 */}
-          <div className="relative flex flex-col">
-            <input
-              type="email"
-              placeholder="이메일"
-              {...register('email', {
-                required: '이메일을 입력해주세요',
-                pattern: {
-                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                  message: '올바른 이메일 형식이 아닙니다.',
-                },
-                // 이메일 중복 검사 API 추가 예정
-              })}
-              className="w-full px-3 py-3 border border-gray-300 rounded-lg bg-[#fefefe] text-base focus:outline-none focus:ring-2 focus:ring-[#0070f3]/30 focus:border-[#0070f3]"
-            />
+          <div className="flex flex-col">
+            <div className="flex gap-2">
+              <input
+                type="email"
+                placeholder="이메일"
+                {...register('email', {
+                  required: '이메일을 입력해주세요',
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: '올바른 이메일 형식이 아닙니다.',
+                  },
+                })}
+                className="w-full px-3 py-3 border border-gray-300 rounded-lg bg-[#fefefe] text-base focus:outline-none focus:ring-2 focus:ring-[#0070f3]/30 focus:border-[#0070f3]"
+              />
+              <button
+                type="button"
+                className="bg-blue-600 text-white font-semibold text-lg whitespace-nowrap px-4 rounded-lg transition-colors hover:bg-blue-700"
+              >
+                인증하기
+              </button>
+            </div>
             {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>}
           </div>
 
@@ -222,8 +229,8 @@ const SignupPage = () => {
           <button
             type="submit"
             disabled={!canSubmit}
-            className={`bg-[#0052cc] text-white font-semibold text-lg py-3 rounded-lg transition-colors ${
-              canSubmit ? 'hover:bg-[#003f9e]' : 'cursor-not-allowed'
+            className={`bg-blue-600 text-white font-semibold text-lg py-3 rounded-lg transition-colors ${
+              canSubmit ? 'hover:bg-blue-700' : 'cursor-not-allowed'
             }`}
           >
             회원가입

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -22,6 +22,7 @@ const SignupPage = () => {
 
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false); // 이메일 인증 중 상태
 
   const {
     register,
@@ -38,6 +39,39 @@ const SignupPage = () => {
   const email = watch('email');
 
   const canSubmit = isValid;
+
+  // 이메일 인증 처리 함수
+  const handleEmailVerification = async () => {
+    if (!email || errors.email) {
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      // 1. 이메일 중복 여부 체크
+      const checkResponse = await axiosInstance.post('/v1/email/check', { email });
+
+      if (checkResponse.data.data === 'Y') {
+        alert('이미 사용 중인 이메일입니다.');
+        setIsVerifying(false);
+        return;
+      }
+
+      // 2. 중복이 없으면 (data === 'N') 인증코드 전송
+      if (checkResponse.data.data === 'N') {
+        await axiosInstance.post('/v1/email/send', { email });
+        alert('인증코드가 전송되었습니다. 이메일을 확인해주세요.');
+      }
+    } catch (error: any) {
+      if (error.response) {
+        alert(`오류: ${error.response.data.message || '알 수 없는 오류가 발생했습니다.'}`);
+      } else {
+        alert('인증코드 전송 중 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsVerifying(false);
+    }
+  };
 
   const onSubmit: SubmitHandler<FormValues> = async (data) => {
     try {
@@ -76,12 +110,15 @@ const SignupPage = () => {
               />
               <button
                 type="button"
-                disabled={!email || !!errors.email}
-                className={`bg-blue-600 text-white font-semibold text-lg whitespace-nowrap px-4 rounded-lg transition-colors ${
-                  !email || errors.email ? 'cursor-not-allowed' : 'hover:bg-blue-700'
+                disabled={!email || !!errors.email || isVerifying}
+                onClick={handleEmailVerification}
+                className={`font-semibold text-lg whitespace-nowrap px-4 rounded-lg transition-colors ${
+                  !email || errors.email || isVerifying
+                    ? 'cursor-not-allowed bg-gray-150 text-gray-600'
+                    : 'bg-blue-600 text-white hover:bg-blue-700'
                 }`}
               >
-                인증하기
+                {isVerifying ? '전송 중...' : '인증하기'}
               </button>
             </div>
             {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>}

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,8 @@
   --color-blue-420: #266db0;
   --color-blue-450: #2b74a5;
   --color-blue-500: #075080;
+  --color-blue-600: #0052cc;
+  --color-blue-700: #003f9e;
 
   --color-gray-50: #fafafa;
   --color-gray-80: #f6f6f6;


### PR DESCRIPTION
## 요약

- 회원가입 시 **이메일 인증 기능**을 구현하고 관련 API를 연동했습니다.  
- 이메일 중복 체크 → 인증코드 발송 → 인증코드 입력 및 검증 → 회원가입 버튼 활성화의 흐름으로 완성했습니다.
<br>

## 작업 내용 - 흐름 기반

### 0. 이메일 입력 후 인증하기 버튼 클릭
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9cca9d68-242f-4e76-8253-65c41abf6562" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0700a61e-1d82-4eb4-8a13-6d631d30918f" />

- 이메일 필드 우측 `인증하기` 버튼 추가
- 이메일 입력값이 비어 있거나 유효하지 않은 경우 버튼 비활성화

### 1. 이메일 중복 확인
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8552ddcd-6f23-4e67-8e3b-6506ccaec1c6" />

- 이메일 중복 여부 체크 API 연동
- 이메일 인증 중 상태 추가
- 인증 중 상태에 따라 인증 버튼 비활성화
- 이메일 인증 처리 함수 추가
- 이메일이 중복이 아닌 경우에만 인증코드 발송 단계로 넘어감

### 2. 인증코드 발송
<img width="300" alt="image" src="https://github.com/user-attachments/assets/27af8385-f5df-48cc-8215-4793953da637" />

- 인증코드 입력 필드 및 확인 버튼 UI 구현
- 인증코드 전송 API 연동
- 인증코드 전송 완료 여부 상태 추가

### 3. 인증코드 확인
<img width="250" alt="image" src="https://github.com/user-attachments/assets/54145cac-ce4c-425f-b216-852a90f5e8cf" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/887253d0-7434-41fb-ad0a-d7c57a6368a4" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/343090ee-c64f-45ae-a25a-ee31ac360ddf" />

- 인증코드 값, 에러, 인증코드 확인 중, 확인 완료 여부 상태 추가
- 인증코드 유효성 검사 로직 추가 (영문자 6자리)
- 유효성 검사 통과 시 `확인` 버튼 활성화
- 인증코드 검증 API 연동
- 인증코드 확인 완료 시 이메일 필드 및 인증코드 필드 수정 불가
- 인증코드 확인 후 회원가입 버튼 활성화
<br>

## 참고 사항

- 전체 스크린샷 (초기 상태)
<img width="5760" height="3366" alt="image" src="https://github.com/user-attachments/assets/c30d61ab-ce09-4cf8-b302-5bdfbfbca9b6" />

<br>

## 관련 이슈

- Closes #34 
