### PR TITLE
[Feat] Code Editor 내부 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.1.12",
+        "@xterm/xterm": "^5.5.0",
         "antd": "^5.27.4",
         "axios": "^1.11.0",
         "framer-motion": "^12.23.16",
@@ -2170,6 +2171,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-hook-form": "^7.62.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.3",
+        "sonner": "^2.0.7",
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
@@ -7015,6 +7016,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hackplay-front",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@tailwindcss/vite": "^4.1.12",
         "antd": "^5.27.4",
         "axios": "^1.11.0",
@@ -1021,6 +1022,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1878,6 +1902,14 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -2971,6 +3003,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -4823,9 +4865,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5241,6 +5283,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5352,6 +5407,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/motion-dom": {
@@ -6953,6 +7019,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7525,9 +7597,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.1.12",
+    "@xterm/xterm": "^5.5.0",
     "antd": "^5.27.4",
     "axios": "^1.11.0",
     "framer-motion": "^12.23.16",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-hook-form": "^7.62.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.3",
+    "sonner": "^2.0.7",
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@tailwindcss/vite": "^4.1.12",
     "antd": "^5.27.4",
     "axios": "^1.11.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter } from 'react-router-dom';
 
+import { Toaster } from 'sonner';
+
 import ScrollToTop from '@/components/ScrollToTop';
 
 import Footer from './components/Footer';
@@ -11,6 +13,7 @@ const App = () => {
     <BrowserRouter>
       <ScrollToTop />
       <Header />
+      <Toaster richColors />
       <main>
         <Router />
       </main>

--- a/src/components/features/BottomPanel.tsx
+++ b/src/components/features/BottomPanel.tsx
@@ -9,9 +9,17 @@ interface BottomPanelProps {
   onOpenWebPage?: () => void;
   terminalOutput?: string;
   onSave?: () => void;
+  isAutoSaveEnabled: boolean;
+  setIsAutoSaveEnabled: (val: boolean) => void;
 }
 
-const BottomPanel = ({ onOpenWebPage, terminalOutput = '', onSave }: BottomPanelProps) => {
+const BottomPanel = ({
+  onOpenWebPage,
+  terminalOutput = '',
+  onSave,
+  isAutoSaveEnabled,
+  setIsAutoSaveEnabled,
+}: BottomPanelProps) => {
   const [isTerminalExpanded, setIsTerminalExpanded] = useState(true);
 
   const terminalDivRef = useRef<HTMLDivElement | null>(null);
@@ -73,6 +81,33 @@ const BottomPanel = ({ onOpenWebPage, terminalOutput = '', onSave }: BottomPanel
         </div>
 
         <div className="flex items-center gap-[1.188rem]">
+          {/* 자동 저장 토글 */}
+          <div className="flex items-center gap-2 pr-2 border-r border-gray-200">
+            <span className="text-xs text-gray-600">자동 저장</span>
+
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={isAutoSaveEnabled}
+                onChange={() => setIsAutoSaveEnabled(!isAutoSaveEnabled)}
+              />
+              <div
+                className="
+                w-10 h-5 bg-gray-300 rounded-full peer
+                peer-checked:bg-blue-500 transition
+              "
+              ></div>
+              <div
+                className="
+                absolute left-0.5 top-0.5 
+                w-4 h-4 bg-white rounded-full 
+                transition-all
+                peer-checked:translate-x-5
+              "
+              ></div>
+            </label>
+          </div>
           <button
             onClick={() => {
               if (onSave) {

--- a/src/components/features/BottomPanel.tsx
+++ b/src/components/features/BottomPanel.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { FaHistory } from 'react-icons/fa';
+import { TfiControlPlay, TfiControlStop, TfiSave } from 'react-icons/tfi';
+
+interface BottomPanelProps {
+  onOpenWebPage?: () => void;
+  onAIScoring?: () => void;
+  terminalOutput?: string;
+}
+
+const BottomPanel = ({ onOpenWebPage, terminalOutput = '' }: BottomPanelProps) => {
+  const [isTerminalExpanded, setIsTerminalExpanded] = useState(true);
+
+  return (
+    <div className="flex flex-col bg-white">
+      {/* 툴바 */}
+      <div className="flex items-center justify-between px-[1.438rem] py-[1.094rem] border-x-[0.5px] border-gray-200">
+        <div className="flex items-center gap-[1.188rem]">
+          <button onClick={onOpenWebPage}>
+            <TfiControlPlay className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
+          </button>
+          <button
+          // onClick={onAIScoring}
+          >
+            <TfiControlStop className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
+          </button>
+        </div>
+        <div className="flex items-center gap-[1.188rem]">
+          {/* <button
+            className="p-2 hover:bg-gray-100 rounded"
+            onClick={() => {
+              // 업로드 기능
+            }}
+            title="업로드"
+          >
+            <HiUpload className="w-4 h-4 text-gray-600" />
+          </button> */}
+          <button>
+            <TfiSave className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
+          </button>
+          <button>
+            <FaHistory className="w-4.5 h-4.5 text-gray-620" />
+          </button>
+        </div>
+      </div>
+
+      {/* 터미널 영역 */}
+      <div className="flex h-[10.625rem] border-t-[0.5px] border-x-[0.5px] border-gray-200 pt-[0.563rem] px-[0.813rem]">
+        {/* <button
+          onClick={() => setIsTerminalExpanded(!isTerminalExpanded)}
+          className="flex items-center justify-between px-4 py-2 bg-gray-50 hover:bg-gray-100 border-b border-gray-200"
+        >
+          <span className="text-xs text-gray-500">{isTerminalExpanded ? '' : ''}</span>
+        </button> */}
+        {isTerminalExpanded && (
+          <div className="bg-white text-gray-630 text-[0.813rem]/[1.54] overflow-y-auto">
+            {terminalOutput || <div>&lt;/&gt; 실행 결과</div>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BottomPanel;

--- a/src/components/features/BottomPanel.tsx
+++ b/src/components/features/BottomPanel.tsx
@@ -8,9 +8,10 @@ import '@xterm/xterm/css/xterm.css';
 interface BottomPanelProps {
   onOpenWebPage?: () => void;
   terminalOutput?: string;
+  onSave?: () => void;
 }
 
-const BottomPanel = ({ onOpenWebPage, terminalOutput = '' }: BottomPanelProps) => {
+const BottomPanel = ({ onOpenWebPage, terminalOutput = '', onSave }: BottomPanelProps) => {
   const [isTerminalExpanded, setIsTerminalExpanded] = useState(true);
 
   const terminalDivRef = useRef<HTMLDivElement | null>(null);
@@ -66,15 +67,19 @@ const BottomPanel = ({ onOpenWebPage, terminalOutput = '' }: BottomPanelProps) =
           <button onClick={handleRun}>
             <TfiControlPlay className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
           </button>
-          <button
-            onClick={handleStop}
-          >
+          <button onClick={handleStop}>
             <TfiControlStop className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
           </button>
         </div>
 
         <div className="flex items-center gap-[1.188rem]">
-          <button>
+          <button
+            onClick={() => {
+              if (onSave) {
+                onSave();
+              }
+            }}
+          >
             <TfiSave className="w-4 h-4 text-gray-620 stroke-[0.5]" />
           </button>
           <button>

--- a/src/components/features/BottomPanel.tsx
+++ b/src/components/features/BottomPanel.tsx
@@ -1,6 +1,9 @@
-import { useState } from 'react';
-import { FaHistory } from 'react-icons/fa';
+import { useEffect, useRef, useState } from 'react';
+import { TbTrash } from 'react-icons/tb';
 import { TfiControlPlay, TfiControlStop, TfiSave } from 'react-icons/tfi';
+
+import { Terminal } from '@xterm/xterm';
+import '@xterm/xterm/css/xterm.css';
 
 interface BottomPanelProps {
   onOpenWebPage?: () => void;
@@ -11,41 +14,79 @@ interface BottomPanelProps {
 const BottomPanel = ({ onOpenWebPage, terminalOutput = '' }: BottomPanelProps) => {
   const [isTerminalExpanded, setIsTerminalExpanded] = useState(true);
 
+  const terminalDivRef = useRef<HTMLDivElement | null>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+
+  // 1. xterm 초기화
+  useEffect(() => {
+    const terminal = new Terminal({
+      convertEol: true,
+      fontSize: 13,
+      fontFamily: 'Menlo, monospace',
+      cursorBlink: true,
+      scrollback: 5000,
+      theme: {
+        background: '#ffffff',
+        foreground: '#1e1e1e',
+      },
+    });
+
+    terminalRef.current = terminal;
+
+    if (terminalDivRef.current) {
+      terminal.open(terminalDivRef.current);
+    }
+
+    return () => {
+      terminal.dispose();
+    };
+  }, []);
+
+  // 2. terminalOutput prop 변화 시 출력
+  useEffect(() => {
+    if (terminalOutput && terminalRef.current) {
+      terminalRef.current.writeln(terminalOutput);
+    }
+  }, [terminalOutput]);
+
+  // 3. Run / Stop 출력 예시
+  const handleRun = () => {
+    terminalRef.current?.writeln('\x1b[32m[Run] Running...\x1b[0m');
+  };
+
+  const handleStop = () => {
+    terminalRef.current?.writeln('\x1b[31m[Stop] Stopped.\x1b[0m');
+  };
+
   return (
     <div className="flex flex-col bg-white">
       {/* 툴바 */}
       <div className="flex items-center justify-between px-[1.438rem] py-[1.094rem] border-x-[0.5px] border-gray-200">
         <div className="flex items-center gap-[1.188rem]">
-          <button onClick={onOpenWebPage}>
+          {/* <button onClick={onOpenWebPage}> */}
+          <button onClick={handleRun}>
             <TfiControlPlay className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
           </button>
           <button
-          // onClick={onAIScoring}
+            // onClick={onAIScoring}
+            onClick={handleStop}
           >
             <TfiControlStop className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
           </button>
         </div>
+
         <div className="flex items-center gap-[1.188rem]">
-          {/* <button
-            className="p-2 hover:bg-gray-100 rounded"
-            onClick={() => {
-              // 업로드 기능
-            }}
-            title="업로드"
-          >
-            <HiUpload className="w-4 h-4 text-gray-600" />
-          </button> */}
           <button>
-            <TfiSave className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
+            <TfiSave className="w-4 h-4 text-gray-620 stroke-[0.5]" />
           </button>
           <button>
-            <FaHistory className="w-4.5 h-4.5 text-gray-620" />
+            <TbTrash className="w-5 h-5 text-gray-620" />
           </button>
         </div>
       </div>
 
       {/* 터미널 영역 */}
-      <div className="flex h-[10.625rem] border-t-[0.5px] border-x-[0.5px] border-gray-200 pt-[0.563rem] px-[0.813rem]">
+      <div className="flex h-[10.625rem] border-t-[0.5px] border-l-[0.5px] border-gray-200 pt-[0.563rem] px-[0.813rem]">
         {/* <button
           onClick={() => setIsTerminalExpanded(!isTerminalExpanded)}
           className="flex items-center justify-between px-4 py-2 bg-gray-50 hover:bg-gray-100 border-b border-gray-200"
@@ -53,9 +94,11 @@ const BottomPanel = ({ onOpenWebPage, terminalOutput = '' }: BottomPanelProps) =
           <span className="text-xs text-gray-500">{isTerminalExpanded ? '' : ''}</span>
         </button> */}
         {isTerminalExpanded && (
-          <div className="bg-white text-gray-630 text-[0.813rem]/[1.54] overflow-y-auto">
-            {terminalOutput || <div>&lt;/&gt; 실행 결과</div>}
-          </div>
+          <div
+            ref={terminalDivRef}
+            id="terminal"
+            className="bg-white w-full h-full overflow-y-auto"
+          />
         )}
       </div>
     </div>

--- a/src/components/features/BottomPanel.tsx
+++ b/src/components/features/BottomPanel.tsx
@@ -7,7 +7,6 @@ import '@xterm/xterm/css/xterm.css';
 
 interface BottomPanelProps {
   onOpenWebPage?: () => void;
-  onAIScoring?: () => void;
   terminalOutput?: string;
 }
 
@@ -68,7 +67,6 @@ const BottomPanel = ({ onOpenWebPage, terminalOutput = '' }: BottomPanelProps) =
             <TfiControlPlay className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />
           </button>
           <button
-            // onClick={onAIScoring}
             onClick={handleStop}
           >
             <TfiControlStop className="w-4.5 h-4.5 text-gray-620 stroke-[0.5]" />

--- a/src/components/features/CodeEditor.tsx
+++ b/src/components/features/CodeEditor.tsx
@@ -1,0 +1,78 @@
+import Editor from '@monaco-editor/react';
+import { useEffect, useRef } from 'react';
+
+interface CodeEditorProps {
+  value: string;
+  language?: string;
+  path: string;
+  onChange: (value: string | undefined) => void;
+  onSave?: () => void;
+}
+
+const CodeEditor = ({ value, language, path, onChange, onSave }: CodeEditorProps) => {
+  const editorRef = useRef<any>(null);
+
+  // 파일 확장자로 언어 자동 감지
+  const detectLanguage = (filePath: string): string => {
+    const ext = filePath.split('.').pop()?.toLowerCase();
+    const languageMap: Record<string, string> = {
+      js: 'javascript',
+      jsx: 'javascript',
+      ts: 'typescript',
+      tsx: 'typescript',
+      html: 'html',
+      css: 'css',
+      json: 'json',
+      py: 'python',
+      java: 'java',
+      cpp: 'cpp',
+      c: 'c',
+      md: 'markdown',
+    };
+    return language || languageMap[ext || ''] || 'plaintext';
+  };
+
+  const handleEditorDidMount = (editor: any, monaco: any) => {
+    editorRef.current = editor;
+
+    // Ctrl+S 또는 Cmd+S로 저장
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+      if (onSave) {
+        onSave();
+      }
+    });
+  };
+
+  useEffect(() => {
+    // 에디터 포커스
+    if (editorRef.current) {
+      editorRef.current.focus();
+    }
+  }, [path]);
+
+  return (
+    <div className="h-full w-full">
+      <Editor
+        height="100%"
+        language={detectLanguage(path)}
+        value={value}
+        onChange={onChange}
+        onMount={handleEditorDidMount}
+        theme="vs"
+        options={{
+          fontSize: 14,
+          minimap: { enabled: true },
+          scrollBeyondLastLine: false,
+          wordWrap: 'off',
+          automaticLayout: true,
+          tabSize: 2,
+          insertSpaces: true,
+          formatOnPaste: true,
+          formatOnType: true,
+        }}
+      />
+    </div>
+  );
+};
+
+export default CodeEditor;

--- a/src/components/features/EditorTabs.tsx
+++ b/src/components/features/EditorTabs.tsx
@@ -1,0 +1,69 @@
+import { MdFolder } from 'react-icons/md';
+import { TfiClose } from 'react-icons/tfi';
+
+interface Tab {
+  id: string;
+  path: string;
+  name: string;
+  isModified: boolean;
+  isSaved: boolean;
+}
+
+interface EditorTabsProps {
+  tabs: Tab[];
+  activeTabId?: string;
+  onTabClick: (tabId: string) => void;
+  onTabClose: (tabId: string) => void;
+}
+
+const EditorTabs = ({ tabs, activeTabId, onTabClick, onTabClose }: EditorTabsProps) => {
+  const handleClose = (e: React.MouseEvent, tabId: string) => {
+    e.stopPropagation();
+    onTabClose(tabId);
+  };
+
+  return (
+    <div className="flex items-center overflow-x-auto h-[2.375rem] max-h-[2.375rem]">
+      <div
+        className={
+          'flex items-center max-w-[4.563rem] bg-gray-150 px-6 pt-[0.563rem] pb-1 rounded-t-2xl h-full'
+        }
+      >
+        <MdFolder className="text-gray-620 w-[1.3rem] h-[1.3rem]" />
+      </div>
+      {tabs.map((tab) => {
+        const isActive = activeTabId === tab.id;
+        return (
+          <div
+            key={tab.id}
+            className={`flex h-full items-center pt-[0.682rem] pb-[0.491rem] pl-[1.553rem] pr-2 gap-6 cursor-pointer rounded-t-2xl ${
+              isActive ? 'bg-white' : 'bg-gray-150'
+            }`}
+            onClick={() => onTabClick(tab.id)}
+          >
+            <span className="text-sm/[1] truncate flex-1 tracking-[0.01em] text-gray-630">
+              {tab.name}
+            </span>
+            {/* {tab.isModified && !tab.isSaved && (
+              <span className="w-2 h-2 rounded-full bg-orange-500" title="변경됨" />
+            )}
+            {tab.isSaved && !tab.isModified && (
+              <span className="text-xs text-gray-400" title="저장됨">
+                ✓
+              </span>
+            )} */}
+            <button
+              className="hover:bg-gray-90 rounded p-1"
+              onClick={(e) => handleClose(e, tab.id)}
+              title="닫기"
+            >
+              <TfiClose className="text-gray-620 w-2.5 h-2.5 stroke-1" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default EditorTabs;

--- a/src/components/features/EditorTabs.tsx
+++ b/src/components/features/EditorTabs.tsx
@@ -36,22 +36,22 @@ const EditorTabs = ({ tabs, activeTabId, onTabClick, onTabClose }: EditorTabsPro
         return (
           <div
             key={tab.id}
-            className={`flex h-full items-center pt-[0.682rem] pb-[0.491rem] pl-[1.553rem] pr-2 gap-6 cursor-pointer rounded-t-2xl ${
+            className={`flex h-full items-center pt-[0.682rem] pb-[0.491rem] pl-[1.553rem] pr-2 gap-2 cursor-pointer rounded-t-2xl ${
               isActive ? 'bg-white' : 'bg-gray-150'
             }`}
             onClick={() => onTabClick(tab.id)}
           >
-            <span className="text-sm/[1] truncate flex-1 tracking-[0.01em] text-gray-630">
+            <span className={`text-sm/[1] truncate flex-1 tracking-[0.01em] ${tab.isModified ? 'text-yellow-500' : 'text-gray-630'}`}>
               {tab.name}
             </span>
-            {/* {tab.isModified && !tab.isSaved && (
-              <span className="w-2 h-2 rounded-full bg-orange-500" title="변경됨" />
+            {tab.isModified && !tab.isSaved && (
+              <span className="w-2 h-2 rounded-full bg-yellow" title="변경됨" />
             )}
             {tab.isSaved && !tab.isModified && (
               <span className="text-xs text-gray-400" title="저장됨">
                 ✓
               </span>
-            )} */}
+            )}
             <button
               className="hover:bg-gray-90 rounded p-1"
               onClick={(e) => handleClose(e, tab.id)}

--- a/src/components/features/FileTree.tsx
+++ b/src/components/features/FileTree.tsx
@@ -1,8 +1,8 @@
 import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { FaChevronDown, FaChevronRight } from 'react-icons/fa6';
+import { LuFiles } from 'react-icons/lu';
 import { MdFolder } from 'react-icons/md';
 import { MdInsertDriveFile } from 'react-icons/md';
-import { TbFiles } from 'react-icons/tb';
 
 interface FileNode {
   name: string;
@@ -123,7 +123,7 @@ const FileTree = ({ files, selectedPath, onFileSelect, onDelete }: FileTreeProps
     <div className="h-full flex flex-col">
       {/* 헤더 */}
       <div className="flex items-center justify-between pt-2.5 pb-2 pl-[1.188rem] border-b-[0.5px] border-gray-200 bg-gray-150">
-        <TbFiles className="w-5 h-5 text-gray-620" />
+        <LuFiles className="w-5 h-5 text-gray-620 stroke-[2.2]" />
       </div>
 
       {/* 파일 트리 */}

--- a/src/components/features/FileTree.tsx
+++ b/src/components/features/FileTree.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FaChevronDown, FaChevronRight } from 'react-icons/fa6';
 import { MdFolder } from 'react-icons/md';
 import { MdInsertDriveFile } from 'react-icons/md';
-import { TbDownload } from 'react-icons/tb';
+import { TbFiles } from 'react-icons/tb';
 
 interface FileNode {
   name: string;
@@ -88,14 +88,7 @@ const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
     <div className="h-full flex flex-col">
       {/* 헤더 */}
       <div className="flex items-center justify-between pt-2.5 pb-2 pl-[1.188rem] border-b-[0.5px] border-gray-200 bg-gray-150">
-        <button
-          onClick={() => {
-            // 다운로드 기능
-          }}
-          title="다운로드"
-        >
-          <TbDownload className="w-5 h-5 text-gray-620" />
-        </button>
+        <TbFiles className="w-5 h-5 text-gray-620" />
       </div>
 
       {/* 파일 트리 */}

--- a/src/components/features/FileTree.tsx
+++ b/src/components/features/FileTree.tsx
@@ -57,12 +57,12 @@ const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
               {isExpanded ? (
                 <FaChevronDown className="w-3.5 h-3.5 text-gray-620 mr-2.5" />
               ) : (
-                <FaChevronRight className="w-3.5 h-3.5 text-gray-260 mr-2.5" />
+                <FaChevronRight className="w-3.5 h-3.5 mr-2.5" />
               )}
               {isExpanded ? (
                 <MdFolder className="w-5 h-5 text-gray-620" />
               ) : (
-                <MdFolder className="w-5 h-5 text-gray-260" />
+                <MdFolder className="w-5 h-5" />
               )}
             </>
           ) : (

--- a/src/components/features/FileTree.tsx
+++ b/src/components/features/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { MouseEvent, useEffect, useRef, useState } from 'react';
 import { FaChevronDown, FaChevronRight } from 'react-icons/fa6';
 import { MdFolder } from 'react-icons/md';
 import { MdInsertDriveFile } from 'react-icons/md';
@@ -15,10 +15,32 @@ interface FileTreeProps {
   files: FileNode[];
   selectedPath?: string;
   onFileSelect: (path: string) => void;
+  onDelete: (path: string) => void; // 삭제 핸들러
 }
 
-const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
+const FileTree = ({ files, selectedPath, onFileSelect, onDelete }: FileTreeProps) => {
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+  const [contextMenu, setContextMenu] = useState<null | { x: number; y: number; filePath: string }>(
+    null,
+  );
+
+  const menuRef = useRef<HTMLDivElement>(null);
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent | globalThis.MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setContextMenu(null);
+      }
+    };
+
+    if (contextMenu) {
+      window.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [contextMenu]);
 
   const toggleFolder = (path: string) => {
     const newExpanded = new Set(expandedFolders);
@@ -34,6 +56,11 @@ const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
     const isExpanded = expandedFolders.has(node.path);
     const isSelected = selectedPath === node.path;
     const isFolder = node.type === 'folder';
+
+    const handleRightClick = (e: MouseEvent) => {
+      e.preventDefault(); // 기본 우클릭 메뉴를 막음
+      setContextMenu({ x: e.clientX, y: e.clientY, filePath: node.path });
+    };
 
     return (
       <div key={node.path}>
@@ -51,6 +78,7 @@ const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
               onFileSelect(node.path);
             }
           }}
+          onContextMenu={handleRightClick} // 우클릭 처리
         >
           {isFolder ? (
             <>
@@ -84,6 +112,13 @@ const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
     );
   };
 
+  const handleDelete = () => {
+    if (contextMenu) {
+      onDelete(contextMenu.filePath);
+      setContextMenu(null); // 메뉴 닫기
+    }
+  };
+
   return (
     <div className="h-full flex flex-col">
       {/* 헤더 */}
@@ -93,6 +128,26 @@ const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
 
       {/* 파일 트리 */}
       <div className="flex-1 overflow-y-auto bg-white">{files.map((file) => renderNode(file))}</div>
+
+      {/* 우클릭 메뉴 */}
+      {contextMenu && (
+        <div
+          ref={menuRef}
+          className="absolute bg-gray-80 border border-gray-50 shadow-lg rounded-md z-dropdown overflow-hidden"
+          style={{ top: contextMenu.y, left: contextMenu.x }}
+        >
+          <ul>
+            <li>
+              <button
+                className="w-full text-left text-base px-3.5 py-1.5 hover:bg-blue-50"
+                onClick={handleDelete}
+              >
+                삭제
+              </button>
+            </li>
+          </ul>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/features/FileTree.tsx
+++ b/src/components/features/FileTree.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { FaChevronDown, FaChevronRight } from 'react-icons/fa6';
+import { MdFolder } from 'react-icons/md';
+import { MdInsertDriveFile } from 'react-icons/md';
+import { TbDownload } from 'react-icons/tb';
+
+interface FileNode {
+  name: string;
+  type: 'file' | 'folder';
+  path: string;
+  children?: FileNode[];
+}
+
+interface FileTreeProps {
+  files: FileNode[];
+  selectedPath?: string;
+  onFileSelect: (path: string) => void;
+}
+
+const FileTree = ({ files, selectedPath, onFileSelect }: FileTreeProps) => {
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+
+  const toggleFolder = (path: string) => {
+    const newExpanded = new Set(expandedFolders);
+    if (newExpanded.has(path)) {
+      newExpanded.delete(path);
+    } else {
+      newExpanded.add(path);
+    }
+    setExpandedFolders(newExpanded);
+  };
+
+  const renderNode = (node: FileNode, level: number = 0) => {
+    const isExpanded = expandedFolders.has(node.path);
+    const isSelected = selectedPath === node.path;
+    const isFolder = node.type === 'folder';
+
+    return (
+      <div key={node.path}>
+        <div
+          className={`flex items-center cursor-pointer ${
+            isSelected
+              ? 'bg-blue-50 text-blue-600'
+              : 'text-gray-260 hover:bg-gray-120 hover:text-gray-620'
+          } ${isFolder ? 'py-2' : 'py-1'}`}
+          style={{ paddingLeft: `${level * 1 + 0.813}rem` }}
+          onClick={() => {
+            if (isFolder) {
+              toggleFolder(node.path);
+            } else {
+              onFileSelect(node.path);
+            }
+          }}
+        >
+          {isFolder ? (
+            <>
+              {isExpanded ? (
+                <FaChevronDown className="w-3.5 h-3.5 text-gray-620 mr-2.5" />
+              ) : (
+                <FaChevronRight className="w-3.5 h-3.5 text-gray-260 mr-2.5" />
+              )}
+              {isExpanded ? (
+                <MdFolder className="w-5 h-5 text-gray-620" />
+              ) : (
+                <MdFolder className="w-5 h-5 text-gray-260" />
+              )}
+            </>
+          ) : (
+            <>
+              <div className="w-7.5" /> {/* spacing */}
+              <MdInsertDriveFile className="w-5 h-5" />
+            </>
+          )}
+          <span
+            className={`ml-[0.281rem] text-gray-260 self-end ${isFolder ? 'text-[1.005rem] leading-[1.18]' : 'text-[0.939rem] leading-[1.2] font-[410]'} ${isFolder && isExpanded ? 'text-gray-620' : 'text-inherit'}`}
+          >
+            {node.name}
+          </span>
+        </div>
+        {isFolder && isExpanded && node.children && (
+          <div>{node.children.map((child) => renderNode(child, level + 1))}</div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between pt-2.5 pb-2 pl-[1.188rem] border-b-[0.5px] border-gray-200 bg-gray-150">
+        <button
+          onClick={() => {
+            // 다운로드 기능
+          }}
+          title="다운로드"
+        >
+          <TbDownload className="w-5 h-5 text-gray-620" />
+        </button>
+      </div>
+
+      {/* 파일 트리 */}
+      <div className="flex-1 overflow-y-auto bg-white">{files.map((file) => renderNode(file))}</div>
+    </div>
+  );
+};
+
+export default FileTree;

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -593,7 +593,11 @@ const CodeEditorPage = () => {
               </div>
 
               {/* 하단 패널 */}
-              <BottomPanel onOpenWebPage={handleOpenWebPage} terminalOutput={terminalOutput} />
+              <BottomPanel
+                onOpenWebPage={handleOpenWebPage}
+                terminalOutput={terminalOutput}
+                onSave={handleSave}
+              />
             </div>
           </div>
         </div>

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -210,6 +210,20 @@ const CodeEditorPage = () => {
     setActiveTabId(newTab.id);
   };
 
+  // 파일 삭제
+  const handleDeleteFile = (filePath: string) => {
+    const removeNode = (nodes: FileNode[]): FileNode[] =>
+      nodes
+        .filter((node) => node.path !== filePath)
+        .map((node) => (node.children ? { ...node, children: removeNode(node.children) } : node));
+
+    setFiles((prev) => removeNode(prev));
+
+    // 삭제된 파일이 현재 열린 탭이면 닫기
+    const tabToClose = editorTabs.find((t) => t.path === filePath);
+    if (tabToClose) handleTabClose(tabToClose.id);
+  };
+
   // 탭 클릭 핸들러
   const handleTabClick = (tabId: string) => {
     setActiveTabId(tabId);
@@ -555,6 +569,7 @@ const CodeEditorPage = () => {
                   files={files}
                   selectedPath={editorTabs.find((t) => t.id === activeTabId)?.path}
                   onFileSelect={handleFileSelect}
+                  onDelete={handleDeleteFile}
                 />
               </div>
             )}

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -5,6 +5,8 @@ import { BsPencilFill } from 'react-icons/bs';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 import { Link, useLocation } from 'react-router-dom';
 
+import { toast } from 'sonner';
+
 import BEDeveloperImg from '@/assets/backend.png';
 import DesignerImg from '@/assets/designer.png';
 import FEDeveloperImg from '@/assets/frontend.png';
@@ -290,7 +292,7 @@ const CodeEditorPage = () => {
       }
     } catch (error) {
       console.error('저장 실패:', error);
-      alert('저장 실패, 다시 시도해주세요.');
+      toast.error('저장 실패, 다시 시도해주세요')
     }
   };
 

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -117,6 +117,7 @@ const CodeEditorPage = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [terminalOutput, setTerminalOutput] = useState<string>('');
+  const [isAutoSaveEnabled, setIsAutoSaveEnabled] = useState(true); // 자동 저장 토글
 
   // 좌측 패널 상단 탭 데이터
   const leftPanelTabs: tabItem[] = [
@@ -254,7 +255,7 @@ const CodeEditorPage = () => {
         tab.id === activeTabId ? { ...tab, isModified: true, isSaved: false } : tab,
       ),
     );
-
+    if (!isAutoSaveEnabled) return;
     // 자동 저장 타이머 리셋
     if (autoSaveTimerRef.current) {
       clearTimeout(autoSaveTimerRef.current);
@@ -292,7 +293,7 @@ const CodeEditorPage = () => {
       }
     } catch (error) {
       console.error('저장 실패:', error);
-      toast.error('저장 실패, 다시 시도해주세요')
+      toast.error('저장 실패, 다시 시도해주세요');
     }
   };
 
@@ -599,6 +600,8 @@ const CodeEditorPage = () => {
                 onOpenWebPage={handleOpenWebPage}
                 terminalOutput={terminalOutput}
                 onSave={handleSave}
+                isAutoSaveEnabled={isAutoSaveEnabled}
+                setIsAutoSaveEnabled={setIsAutoSaveEnabled}
               />
             </div>
           </div>

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -105,6 +105,7 @@ const CodeEditorPage = () => {
         { name: '텍스트를 입력하세요 6', type: 'file', path: '/src/텍스트를 입력하세요 6' },
         { name: '텍스트를 입력하세요 7', type: 'file', path: '/src/텍스트를 입력하세요 7' },
         { name: '텍스트를 입력하세요 8', type: 'file', path: '/src/텍스트를 입력하세요 8' },
+        { name: '텍스트를 입력하세요 9', type: 'file', path: '/src/텍스트를 입력하세요 9' },
       ],
     },
   ]);
@@ -225,9 +226,12 @@ const CodeEditorPage = () => {
     // 닫은 탭이 활성 탭이었다면 다른 탭으로 전환
     if (activeTabId === tabId) {
       if (newTabs.length > 0) {
-        setActiveTabId(newTabs[newTabs.length - 1].id);
+        // 이전 탭이 있으면 그걸, 없으면 다음 탭
+        const newActiveIdx = newTabs.findIndex((tab) => tab.id === tabId);
+        const newActiveTab = newTabs[newActiveIdx >= 0 ? newActiveIdx - 1 : 0];
+        setActiveTabId(newActiveTab.id); // 새 탭을 활성화
       } else {
-        setActiveTabId(undefined);
+        setActiveTabId(undefined); // 탭이 하나도 없으면 activeTabId를 undefined로
       }
     }
   };
@@ -589,10 +593,7 @@ const CodeEditorPage = () => {
               </div>
 
               {/* 하단 패널 */}
-              <BottomPanel
-                onOpenWebPage={handleOpenWebPage}
-                terminalOutput={terminalOutput}
-              />
+              <BottomPanel onOpenWebPage={handleOpenWebPage} terminalOutput={terminalOutput} />
             </div>
           </div>
         </div>

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -86,7 +86,7 @@ const CodeEditorPage = () => {
   const userRole = JOB_TYPES.FE; // 사용자 직무
   const [activeTab, setActiveTab] = useState<'overview' | 'request' | 'answer'>('overview');
   const [currentRequestIndex, setCurrentRequestIndex] = useState<number>(0); // 직무별 요청사항 현재 인덱스
-  const noRequest = path === '/workspaces/team-project-1' || path === '/workspaces/team-project-2'; // 1, 2주차는 요청사항 없음
+  const noRequest = path === '/workspaces/team-project-1'; // 1주차는 요청사항 없음
 
   // 코드 에디터 관련 상태
   const [files, setFiles] = useState<FileNode[]>([
@@ -312,9 +312,13 @@ const CodeEditorPage = () => {
   }, []);
 
   return (
-    <div className="px-[3.164rem] pt-[1.009rem] pb-[2.688rem] flex gap-[0.813rem] h-[calc(100vh-5.095rem)]">
+    <div
+      className={`px-[3.164rem] pt-[1.009rem] pb-[2.688rem] flex gap-[0.813rem] h-[calc(100vh-5.095rem)] ${noRequest ? 'justify-center' : ''}`}
+    >
       {/* 좌측 패널 */}
-      <div className="bg-gray-90 p-[0.969rem] flex-[0_0_31.9%] max-w-[31.9%] rounded-2xl shadow-1 flex flex-col">
+      <div
+        className={`bg-gray-90 p-[0.969rem] rounded-2xl shadow-1 flex flex-col ${noRequest ? 'w-full max-w-1/2' : 'flex-[0_0_31.9%] max-w-[31.9%]'}`}
+      >
         {/* 좌측 패널 - 탭 */}
         <div className="flex gap-[0.063rem]">
           {leftPanelTabs.map((tab) => {
@@ -540,64 +544,66 @@ const CodeEditorPage = () => {
       </div>
 
       {/* 코드 에디터 영역 */}
-      <div className="flex-1 flex bg-gray-90 rounded-2xl shadow-1 overflow-hidden pt-[0.969rem] pl-[0.969rem]">
-        <div className="flex flex-1 overflow-hidden gap-1.5">
-          {/* 파일 트리 사이드바 */}
-          {isSidebarOpen && (
-            <div className="flex-[0_0_24%] flex-shrink-0 border-[0.5px] border-gray-200 rounded-2xl rounded-br-none overflow-hidden">
-              <FileTree
-                files={files}
-                selectedPath={editorTabs.find((t) => t.id === activeTabId)?.path}
-                onFileSelect={handleFileSelect}
+      {noRequest ? null : (
+        <div className="flex-1 flex bg-gray-90 rounded-2xl shadow-1 overflow-hidden pt-[0.969rem] pl-[0.969rem]">
+          <div className="flex flex-1 overflow-hidden gap-1.5">
+            {/* 파일 트리 사이드바 */}
+            {isSidebarOpen && (
+              <div className="flex-[0_0_24%] flex-shrink-0 border-[0.5px] border-gray-200 rounded-2xl rounded-br-none overflow-hidden">
+                <FileTree
+                  files={files}
+                  selectedPath={editorTabs.find((t) => t.id === activeTabId)?.path}
+                  onFileSelect={handleFileSelect}
+                />
+              </div>
+            )}
+
+            {/* 에디터 영역 */}
+            <div className="flex-1 flex flex-col overflow-hidden">
+              {/* 탭 바 */}
+              <EditorTabs
+                tabs={editorTabs}
+                activeTabId={activeTabId}
+                onTabClick={handleTabClick}
+                onTabClose={handleTabClose}
               />
-            </div>
-          )}
 
-          {/* 에디터 영역 */}
-          <div className="flex-1 flex flex-col overflow-hidden">
-            {/* 탭 바 */}
-            <EditorTabs
-              tabs={editorTabs}
-              activeTabId={activeTabId}
-              onTabClick={handleTabClick}
-              onTabClose={handleTabClose}
-            />
-
-            {/* Monaco Editor */}
-            <div className="flex-1 border-[0.5px] border-gray-200 rounded-tr-2xl overflow-hidden bg-white">
-              {activeTabId ? (
-                <div className="w-full h-full">
-                  <CodeEditor
-                    value={
-                      fileContents[editorTabs.find((t) => t.id === activeTabId)?.path || ''] || ''
-                    }
-                    path={editorTabs.find((t) => t.id === activeTabId)?.path || ''}
-                    onChange={handleEditorChange}
-                    onSave={handleSave}
-                  />
-                </div>
-              ) : (
-                <div className="w-full h-full flex items-center justify-center">
-                  <div className="flex items-center justify-center w-full h-full">
-                    <img
-                      src={`${import.meta.env.BASE_URL}favicon/android-chrome-512x512.png`}
-                      alt="아이콘"
-                      className="grayscale brightness-110 h-1/3"
+              {/* Monaco Editor */}
+              <div className="flex-1 border-[0.5px] border-gray-200 rounded-tr-2xl overflow-hidden bg-white">
+                {activeTabId ? (
+                  <div className="w-full h-full">
+                    <CodeEditor
+                      value={
+                        fileContents[editorTabs.find((t) => t.id === activeTabId)?.path || ''] || ''
+                      }
+                      path={editorTabs.find((t) => t.id === activeTabId)?.path || ''}
+                      onChange={handleEditorChange}
+                      onSave={handleSave}
                     />
                   </div>
-                </div>
-              )}
-            </div>
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center">
+                    <div className="flex items-center justify-center w-full h-full">
+                      <img
+                        src={`${import.meta.env.BASE_URL}favicon/android-chrome-512x512.png`}
+                        alt="아이콘"
+                        className="grayscale brightness-110 h-1/3"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
 
-            {/* 하단 패널 */}
-            <BottomPanel
-              onOpenWebPage={handleOpenWebPage}
-              // onAIScoring={handleAIScoring}
-              terminalOutput={terminalOutput}
-            />
+              {/* 하단 패널 */}
+              <BottomPanel
+                onOpenWebPage={handleOpenWebPage}
+                // onAIScoring={handleAIScoring}
+                terminalOutput={terminalOutput}
+              />
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <LockModal
         isOpen={isLockModalOpen}

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AiFillFileText } from 'react-icons/ai';
 import { BiSolidUser } from 'react-icons/bi';
 import { BsPencilFill } from 'react-icons/bs';
@@ -10,6 +10,10 @@ import DesignerImg from '@/assets/designer.png';
 import FEDeveloperImg from '@/assets/frontend.png';
 import PlannerImg from '@/assets/planner.png';
 import LockModal from '@/components/LockModal';
+import BottomPanel from '@/components/features/BottomPanel';
+import CodeEditor from '@/components/features/CodeEditor';
+import EditorTabs from '@/components/features/EditorTabs';
+import FileTree from '@/components/features/FileTree';
 import { JOB_TYPES } from '@/constants/jobTypes';
 import { useLockModal } from '@/hooks/useLockModal';
 
@@ -37,6 +41,23 @@ interface Request {
 interface RequestBoxProps {
   title: string;
   content: string;
+}
+
+// 파일 트리 노드 인터페이스
+interface FileNode {
+  name: string;
+  type: 'file' | 'folder';
+  path: string;
+  children?: FileNode[];
+}
+
+// 탭 인터페이스
+interface Tab {
+  id: string;
+  path: string;
+  name: string;
+  isModified: boolean;
+  isSaved: boolean;
 }
 
 // 요청사항 및 작업 절차 박스 컴포넌트
@@ -67,8 +88,35 @@ const CodeEditorPage = () => {
   const [currentRequestIndex, setCurrentRequestIndex] = useState<number>(0); // 직무별 요청사항 현재 인덱스
   const noRequest = path === '/workspaces/team-project-1' || path === '/workspaces/team-project-2'; // 1, 2주차는 요청사항 없음
 
+  // 코드 에디터 관련 상태
+  const [files, setFiles] = useState<FileNode[]>([
+    {
+      name: '텍스트를 입력하세요',
+      type: 'folder',
+      path: '/src',
+      children: [
+        { name: 'index.html', type: 'file', path: '/src/index.html' },
+        { name: '텍스트를 입력하세요', type: 'file', path: '/src/텍스트를 입력하세요' },
+        { name: '텍스트를 입력하세요 1', type: 'file', path: '/src/텍스트를 입력하세요 1' },
+        { name: '텍스트를 입력하세요 2', type: 'file', path: '/src/텍스트를 입력하세요 2' },
+        { name: '텍스트를 입력하세요 3', type: 'file', path: '/src/텍스트를 입력하세요 3' },
+        { name: '텍스트를 입력하세요 4', type: 'file', path: '/src/텍스트를 입력하세요 4' },
+        { name: '텍스트를 입력하세요 5', type: 'file', path: '/src/텍스트를 입력하세요 5' },
+        { name: '텍스트를 입력하세요 6', type: 'file', path: '/src/텍스트를 입력하세요 6' },
+        { name: '텍스트를 입력하세요 7', type: 'file', path: '/src/텍스트를 입력하세요 7' },
+        { name: '텍스트를 입력하세요 8', type: 'file', path: '/src/텍스트를 입력하세요 8' },
+      ],
+    },
+  ]);
+  const [editorTabs, setEditorTabs] = useState<Tab[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | undefined>();
+  const [fileContents, setFileContents] = useState<Record<string, string>>({});
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [terminalOutput, setTerminalOutput] = useState<string>('');
+
   // 좌측 패널 상단 탭 데이터
-  const tabs: tabItem[] = [
+  const leftPanelTabs: tabItem[] = [
     { key: 'overview', icon: AiFillFileText, sizeClass: 'w-6 h-6' },
     { key: 'request', icon: BiSolidUser, sizeClass: 'w-7 h-7 translate-y-1/3' },
     { key: 'answer', icon: BsPencilFill },
@@ -91,7 +139,7 @@ const CodeEditorPage = () => {
       image: PlannerImg,
       content:
         '회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요.',
-        // '회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요.',
+      // '회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요. 회원가입은 이름/이메일/비밀번호/비밀번호 확인 4개 입력이에요. 전부 입력되기 전까지 가입 버튼 비활성화 해주세요. 성공하면 /login으로 이동하고, 실패 시 현재 페이지에서 에러만 보여주세요. 비밀번호는 최소 8자 권장 문구 넣어주세요. 로딩 중엔 버튼 라벨을 **‘가입 중…’**으로 바꿔주세요.',
     },
     {
       role: JOB_TYPES.DESIGN,
@@ -124,13 +172,152 @@ const CodeEditorPage = () => {
     handleLockedItemClick(e);
   };
 
+  // 파일 선택 핸들러
+  const handleFileSelect = (filePath: string) => {
+    // 이미 열려있는 탭인지 확인
+    const existingTab = editorTabs.find((tab) => tab.path === filePath);
+    if (existingTab) {
+      setActiveTabId(existingTab.id);
+      return;
+    }
+
+    // 최대 10개 탭 제한
+    if (editorTabs.length >= 10) {
+      alert('최대 10개까지 파일을 열 수 있습니다.');
+      return;
+    }
+
+    // 새 탭 생성
+    const fileName = filePath.split('/').pop() || 'untitled';
+    const newTab: Tab = {
+      id: `tab-${Date.now()}`,
+      path: filePath,
+      name: fileName,
+      isModified: false,
+      isSaved: true,
+    };
+
+    // 파일 내용 로드 (없으면 빈 문자열)
+    if (!fileContents[filePath]) {
+      setFileContents((prev) => ({ ...prev, [filePath]: '' }));
+    }
+
+    setEditorTabs((prev) => [...prev, newTab]);
+    setActiveTabId(newTab.id);
+  };
+
+  // 탭 클릭 핸들러
+  const handleTabClick = (tabId: string) => {
+    setActiveTabId(tabId);
+  };
+
+  // 탭 닫기 핸들러
+  const handleTabClose = (tabId: string) => {
+    const tab = editorTabs.find((t) => t.id === tabId);
+    if (tab?.isModified) {
+      const shouldClose = window.confirm('저장되지 않은 변경사항이 있습니다. 정말 닫으시겠습니까?');
+      if (!shouldClose) return;
+    }
+
+    const newTabs = editorTabs.filter((t) => t.id !== tabId);
+    setEditorTabs(newTabs);
+
+    // 닫은 탭이 활성 탭이었다면 다른 탭으로 전환
+    if (activeTabId === tabId) {
+      if (newTabs.length > 0) {
+        setActiveTabId(newTabs[newTabs.length - 1].id);
+      } else {
+        setActiveTabId(undefined);
+      }
+    }
+  };
+
+  // 에디터 내용 변경 핸들러
+  const handleEditorChange = (value: string | undefined) => {
+    if (!activeTabId) return;
+
+    const activeTab = editorTabs.find((t) => t.id === activeTabId);
+    if (!activeTab) return;
+
+    const newValue = value || '';
+    setFileContents((prev) => ({ ...prev, [activeTab.path]: newValue }));
+
+    // 변경 상태 업데이트
+    setEditorTabs((prev) =>
+      prev.map((tab) =>
+        tab.id === activeTabId ? { ...tab, isModified: true, isSaved: false } : tab,
+      ),
+    );
+
+    // 자동 저장 타이머 리셋
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current);
+    }
+
+    // 2초 후 자동 저장
+    autoSaveTimerRef.current = setTimeout(() => {
+      handleSave();
+    }, 2000);
+  };
+
+  // 저장 핸들러
+  const handleSave = async () => {
+    if (!activeTabId) return;
+
+    const activeTab = editorTabs.find((t) => t.id === activeTabId);
+    if (!activeTab) return;
+
+    try {
+      // TODO: 실제 API 호출로 대체
+      // await axiosInstance.put(`/v1/files${activeTab.path}`, {
+      //   content: fileContents[activeTab.path],
+      // });
+
+      // 저장 성공
+      setEditorTabs((prev) =>
+        prev.map((tab) =>
+          tab.id === activeTabId ? { ...tab, isModified: false, isSaved: true } : tab,
+        ),
+      );
+
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
+      }
+    } catch (error) {
+      console.error('저장 실패:', error);
+      alert('저장 실패, 다시 시도해주세요.');
+    }
+  };
+
+  // 웹 페이지 열기 핸들러
+  const handleOpenWebPage = () => {
+    // TODO: 웹 페이지 열기 기능 구현
+    setTerminalOutput('웹 페이지를 여는 중...');
+  };
+
+  // AI 셀프 채점 핸들러
+  // const handleAIScoring = () => {
+  //   // TODO: AI 셀프 채점 기능 구현
+  //   setTerminalOutput('AI 셀프 채점을 시작합니다...');
+  // };
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+      }
+    };
+  }, []);
+
   return (
     <div className="px-[3.164rem] pt-[1.009rem] pb-[2.688rem] flex gap-[0.813rem] h-[calc(100vh-5.095rem)]">
       {/* 좌측 패널 */}
       <div className="bg-gray-90 p-[0.969rem] flex-[0_0_31.9%] max-w-[31.9%] rounded-2xl shadow-1 flex flex-col">
         {/* 좌측 패널 - 탭 */}
         <div className="flex gap-[0.063rem]">
-          {tabs.map((tab) => {
+          {leftPanelTabs.map((tab) => {
             return (
               <button
                 key={tab.key}
@@ -351,7 +538,66 @@ const CodeEditorPage = () => {
           )}
         </div>
       </div>
-      <div>코드 에디터</div>
+
+      {/* 코드 에디터 영역 */}
+      <div className="flex-1 flex bg-gray-90 rounded-2xl shadow-1 overflow-hidden pt-[0.969rem] pl-[0.969rem]">
+        <div className="flex flex-1 overflow-hidden gap-1.5">
+          {/* 파일 트리 사이드바 */}
+          {isSidebarOpen && (
+            <div className="flex-[0_0_24%] flex-shrink-0 border-[0.5px] border-gray-200 rounded-2xl rounded-br-none overflow-hidden">
+              <FileTree
+                files={files}
+                selectedPath={editorTabs.find((t) => t.id === activeTabId)?.path}
+                onFileSelect={handleFileSelect}
+              />
+            </div>
+          )}
+
+          {/* 에디터 영역 */}
+          <div className="flex-1 flex flex-col overflow-hidden">
+            {/* 탭 바 */}
+            <EditorTabs
+              tabs={editorTabs}
+              activeTabId={activeTabId}
+              onTabClick={handleTabClick}
+              onTabClose={handleTabClose}
+            />
+
+            {/* Monaco Editor */}
+            <div className="flex-1 border-[0.5px] border-gray-200 rounded-tr-2xl overflow-hidden bg-white">
+              {activeTabId ? (
+                <div className="w-full h-full">
+                  <CodeEditor
+                    value={
+                      fileContents[editorTabs.find((t) => t.id === activeTabId)?.path || ''] || ''
+                    }
+                    path={editorTabs.find((t) => t.id === activeTabId)?.path || ''}
+                    onChange={handleEditorChange}
+                    onSave={handleSave}
+                  />
+                </div>
+              ) : (
+                <div className="w-full h-full flex items-center justify-center">
+                  <div className="flex items-center justify-center w-full h-full">
+                    <img
+                      src={`${import.meta.env.BASE_URL}favicon/android-chrome-512x512.png`}
+                      alt="아이콘"
+                      className="grayscale brightness-110 h-1/3"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* 하단 패널 */}
+            <BottomPanel
+              onOpenWebPage={handleOpenWebPage}
+              // onAIScoring={handleAIScoring}
+              terminalOutput={terminalOutput}
+            />
+          </div>
+        </div>
+      </div>
 
       <LockModal
         isOpen={isLockModalOpen}

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -117,7 +117,16 @@ const CodeEditorPage = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [terminalOutput, setTerminalOutput] = useState<string>('');
-  const [isAutoSaveEnabled, setIsAutoSaveEnabled] = useState(true); // 자동 저장 토글
+
+  // 자동 저장 토글
+  const [isAutoSaveEnabled, setIsAutoSaveEnabled] = useState(() => {
+    // 초기값을 localStorage에서 읽어오기
+    const stored = localStorage.getItem('isAutoSaveEnabled');
+    return stored !== null ? JSON.parse(stored) : true;
+  });
+  useEffect(() => {
+    localStorage.setItem('isAutoSaveEnabled', JSON.stringify(isAutoSaveEnabled));
+  }, [isAutoSaveEnabled]);
 
   // 좌측 패널 상단 탭 데이터
   const leftPanelTabs: tabItem[] = [

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -142,7 +142,7 @@ const CodeEditorPage = () => {
                     setActiveTab(tab.key);
                   }
                 }}
-                className={`basis-1/3 rounded-t-2xl h-[4.375rem] flex justify-center shadow-1 last:shadow-none ${activeTab === tab.key ? 'bg-white' : 'bg-gray-150'}`}
+                className={`basis-1/3 rounded-t-2xl h-[4.375rem] flex items-stretch! justify-center shadow-1 last:shadow-none ${activeTab === tab.key ? 'bg-white' : 'bg-gray-150'}`}
               >
                 <tab.icon className={`translate-y-1/2 ${tab.sizeClass ?? ''}`} />
               </button>

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -296,12 +296,6 @@ const CodeEditorPage = () => {
     setTerminalOutput('웹 페이지를 여는 중...');
   };
 
-  // AI 셀프 채점 핸들러
-  // const handleAIScoring = () => {
-  //   // TODO: AI 셀프 채점 기능 구현
-  //   setTerminalOutput('AI 셀프 채점을 시작합니다...');
-  // };
-
   // 컴포넌트 언마운트 시 타이머 정리
   useEffect(() => {
     return () => {
@@ -597,7 +591,6 @@ const CodeEditorPage = () => {
               {/* 하단 패널 */}
               <BottomPanel
                 onOpenWebPage={handleOpenWebPage}
-                // onAIScoring={handleAIScoring}
                 terminalOutput={terminalOutput}
               />
             </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,14 +47,18 @@
   --color-gray-80: #f6f6f6;
   --color-gray-90: #f5f5f5;
   --color-gray-100: #f4f4f4;
+  --color-gray-120: #f3f3f3;
   --color-gray-150: #eeeeee;
   --color-gray-200: #d9d9d9;
   --color-gray-250: #cfcfcf;
+  --color-gray-260: #cacaca;
   --color-gray-270: #c9c9c9;
   --color-gray-300: #c0c0c0;
   --color-gray-400: #a8a8a8;
   --color-gray-500: #939393;
   --color-gray-600: #888888;
+  --color-gray-620: #666666;
+  --color-gray-630: #5d5d5d;
   --color-gray-650: #474747;
   --color-gray-700: #363636;
 


### PR DESCRIPTION
## 요약

- Code Editor 영역의 **좌측 파일 트리, 상단 탭 바, 중앙 에디터, 하단 패널**의 UI 및 기능을 구현했습니다.
<br>

## 작업 내용

### 0. 패키지 설치
- `monaco-editor` 패키지 설치
- `@xterm/xterm` 의존성 추가
- `sonner` 패키지 추가

---

### 1. 파일 트리
<img width="200" alt="image" src="https://github.com/user-attachments/assets/f6902bd3-dfe7-4f87-ac2b-9fe3d42adf86" />

- `FileTree` 컴포넌트 추가
- 헤더 아이콘 변경 (`download` → `files`)
- 폴더 열기/접기 구현
- 우클릭 메뉴 및 파일 삭제 기능 구현
- 파일 열기: 파일 클릭 -> 탭에 파일 오픈 (이미 열려 있으면 해당 탭으로 포커스)
- hover 및 selected 스타일 추가

---

### 2. 상단 탭 바
<img width="300" alt="image" src="https://github.com/user-attachments/assets/99efcef4-e835-4e4f-8a0e-db0ba219a0b6" />

- `EditorTabs` 컴포넌트 추가
- 활성/비활성 탭 스타일 적용
- 파일 변경사항 감지 및 변경상태 UI 표시
<img width="290" alt="image" src="https://github.com/user-attachments/assets/5ebc83e4-c151-49e7-befe-ce56beb69bce" />

- 열린 탭: 최대 10개 제한
<img width="290" alt="image" src="https://github.com/user-attachments/assets/453b14b8-278f-4215-ae25-de45ab8394fc" />

- 탭 닫기: 닫기 버튼 클릭 -> 탭 제거 (변경사항 경고)
- 탭 닫으면 이전 활성 탭으로 포커스 이동

---

### 3. 중앙 에디터
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e7b4954e-3069-4ff0-a594-141f8e57b207" />

- `CodeEditor`컴포넌트 추가
- `Monaco Editor` 삽입
- 파일 내용 표시
- 코드 작성 및 수정
- 파일 확장자 기반 언어 자동 감지
- 2초 지연 자동 저장
- Ctrl(Cmd)+S 수동 저장

---

### 4. 하단 패널
<img width="500" alt="image" src="https://github.com/user-attachments/assets/f6be8b7c-f7e2-4772-b315-c8d00eb2f896" />

- `BottomPanel` 컴포넌트 추가
- xterm 터미널 삽입
- 기존 `웹 페이지 열기`, `AI 셀프 채점` 버튼 -> 각각 코드 `실행`, `중지` 버튼으로 변경
- 기존 `다운로드`, `히스토리` 버튼 -> 각각 `저장`, `휴지통` 버튼으로 변경
- `실행`/`중지` 버튼: 현재 기능 X. 임시 텍스트 출력
- 자동 저장 ON/OFF 토글 기능 추가
- `저장` 버튼: 클릭 시 변경사항 저장
- `휴지통` 버튼: 현재 기능 X. 추후 터미널 clear 기능 추가 예정
- 자동 저장 설정을 localStorage에 저장/로드
<img width="290" alt="image" src="https://github.com/user-attachments/assets/04a3d065-ea9d-4fd8-a69b-409a037f72f9" />

- 자동 저장 실패 시 우측 하단 toast

---

### 5. 디자인 수정
- `styles.css`에 새로운 회색 색상 변수 추가 (`gray-120`, `gray-260`, `gray-620`, `gray-630`)
- 코드 실습 미포함 주차 레이아웃 조정 (우측 코드 에디터 영역 삭제)
<br>

## 참고 사항

- 전체 스크린샷 (코드 실습 포함 주차)
<img width="5760" height="3891" alt="image" src="https://github.com/user-attachments/assets/cb8d5fd0-435b-417f-a3b1-580384954449" />

- 전체 스크린샷 (코드 실습 미포함 주차)
<img width="5757" height="3888" alt="image" src="https://github.com/user-attachments/assets/8b3aa5a1-aa53-42bd-96f1-013723e15230" />

[monaco editor](https://monaco-react.surenatoyan.com)
[xterm](https://xtermjs.org)
[sonnar](https://sonner.emilkowal.ski/getting-started)

<br>

## 관련 이슈

- Closes #36 
