### PR TITLE
[Feat] 로그아웃 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.3",
         "sonner": "^2.0.7",
-        "tailwindcss": "^4.1.12"
+        "tailwindcss": "^4.1.12",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1889,7 +1890,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7854,6 +7855,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.3",
         "sonner": "^2.0.7",
+        "sweetalert2": "^11.26.10",
+        "sweetalert2-react-content": "^5.1.1",
         "tailwindcss": "^4.1.12",
         "zustand": "^5.0.9"
       },
@@ -7243,6 +7245,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.26.10",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.26.10.tgz",
+      "integrity": "sha512-l/aaL9WWbumBOaMvcs4aCKzyQwkQCplSmSGpJD7FuRcSDWZyr2OEDmtcSPj2/w3N2TC2xw48Vg5cL6IkUJnPlQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
+    "node_modules/sweetalert2-react-content": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sweetalert2-react-content/-/sweetalert2-react-content-5.1.1.tgz",
+      "integrity": "sha512-JR1DWKQVCSy87q2gNGv5pZgG4TK/x1X61N/HbvDdKmnkCWCSSulG7JfFR8qSB32+H+6nvonsIcevZD7mzRpF0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "sweetalert2": "^11.0.0"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.3",
     "sonner": "^2.0.7",
+    "sweetalert2": "^11.26.10",
+    "sweetalert2-react-content": "^5.1.1",
     "tailwindcss": "^4.1.12",
     "zustand": "^5.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.3",
     "sonner": "^2.0.7",
-    "tailwindcss": "^4.1.12"
+    "tailwindcss": "^4.1.12",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,20 @@
+import { useEffect } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 
 import { Toaster } from 'sonner';
 
 import ScrollToTop from '@/components/ScrollToTop';
+import { useAuthStore } from '@/store/authStore';
 
 import Router from './router/router';
 
 const App = () => {
+  const hydrate = useAuthStore((state) => state.hydrate);
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
   return (
     <BrowserRouter>
       <ScrollToTop />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,20 +4,14 @@ import { Toaster } from 'sonner';
 
 import ScrollToTop from '@/components/ScrollToTop';
 
-import Footer from './components/Footer';
-import Header from './components/Header';
 import Router from './router/router';
 
 const App = () => {
   return (
     <BrowserRouter>
       <ScrollToTop />
-      <Header />
       <Toaster richColors />
-      <main>
-        <Router />
-      </main>
-      <Footer />
+      <Router />
     </BrowserRouter>
   );
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -10,6 +10,12 @@ const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   (request) => {
+    // 토큰이 있으면 헤더에 추가
+    const token = localStorage.getItem('accessToken');
+    if (token) {
+      request.headers.Authorization = `Bearer ${token}`;
+    }
+
     if (import.meta.env.MODE === 'development') {
       console.log('🚀 Axios Request:', {
         method: request.method?.toUpperCase(),

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+import { ROUTES } from '@/constants/routes';
+import { useAuthStore } from '@/store/authStore';
+
 const axiosInstance = axios.create({
   baseURL: `${import.meta.env.VITE_SERVER_BASEURL}/api`,
   withCredentials: true,
@@ -36,9 +39,26 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   (error) => {
+    const status = error.response?.status;
+
+    // 인증 만료 또는 로그아웃 이후 보호된 API 접근 시 처리
+    if (status === 401) {
+      const { isLoggedIn, logout } = useAuthStore.getState();
+
+      // 스토어/스토리지 정리
+      if (isLoggedIn) {
+        logout();
+      }
+
+      // 로그인 페이지로 이동 (이미 로그인 페이지가 아니라면)
+      if (typeof window !== 'undefined' && window.location.pathname !== ROUTES.SIGNIN) {
+        window.location.replace(ROUTES.SIGNIN);
+      }
+    }
+
     if (import.meta.env.MODE === 'development') {
       console.error('❌ Axios Response Error:', {
-        status: error.response?.status,
+        status,
         statusText: error.response?.statusText,
         fullURL: `${error.config?.baseURL}${error.config?.url}`,
         data: error.response?.data,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -129,7 +129,7 @@ const Header = () => {
             className={`flex items-center overflow-hidden w-full rounded-4xl bg-white ${
               isCodeEditorPage
                 ? 'mr-5 max-w-[8.401rem] h-11 pt-[0.883rem] px-[1.421rem] pb-[0.846rem] shadow-1'
-                : 'mr-[1.813rem] max-w-[13.938rem] h-[4.563rem] pt-[1.438rem] px-[2.313rem] pb-[1.378rem]'
+                : 'mr-[3.438rem] max-w-[13.938rem] h-[4.563rem] pt-[1.438rem] px-[2.313rem] pb-[1.378rem]'
             }`}
           >
             <img src={logo} alt="logo" className="object-contain" />
@@ -144,7 +144,7 @@ const Header = () => {
             </div>
           ) : (
             // 내비게이션
-            <ul className="flex w-full h-full mr-4 px-[4.281rem] header-white-box text-gray-600 justify-between">
+            <ul className="flex w-full h-full mr-7 px-[6.063rem] header-white-box text-gray-600 justify-between">
               {NAV_ITEMS.map((item) => (
                 <li key={item.label} className="h-full flex items-center tracking-[0.04em]">
                   {item.locked ? (
@@ -170,14 +170,14 @@ const Header = () => {
               <div className="mr-5 h-full w-[10.313rem] header-white-box"></div>
             ) : (
               <>
-                {!isLoggedIn ? (
-                  <button className="mr-5 h-full max-w-[11.813rem] header-white-box px-[2.564rem] whitespace-nowrap">
+                {isLoggedIn ? (
+                  <button className="mr-[2.438rem] h-full max-w-[12.375rem] header-white-box px-[2.564rem] whitespace-nowrap">
                     학습 이어하기
                   </button>
                 ) : (
                   <Link
                     to={ROUTES.SIGNIN}
-                    className="mr-[1.563rem] w-[8.875rem] max-w-[8.875rem] h-full flex items-center justify-between header-white-box pl-[2.125rem] pr-[1.8rem] whitespace-nowrap"
+                    className="mr-[2.938rem] ml-5 w-[8.875rem] max-w-[8.875rem] h-full flex items-center justify-between header-white-box pl-[2.125rem] pr-[1.8rem] whitespace-nowrap"
                   >
                     로그인 <TfiAngleRight />
                   </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,10 +12,12 @@ import { useLockModal } from '@/hooks/useLockModal';
 import { useAuthStore } from '@/store/authStore';
 
 import LockModal from './LockModal';
+import LogoutModal from './LogoutModal';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showHeaderShadow, setShowHeaderShadow] = useState(false);
+  const [isLogoutModalOpen, setIsLogoutModalOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
   const location = useLocation();
@@ -220,7 +222,7 @@ const Header = () => {
                   {isLoggedIn && (
                     <button
                       className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                      onClick={() => alert('로그아웃')}
+                      onClick={() => setIsLogoutModalOpen(true)}
                     >
                       로그아웃
                     </button>
@@ -233,6 +235,14 @@ const Header = () => {
       </header>
 
       <LockModal isOpen={isLockModalOpen} onClose={closeLockModal} />
+      <LogoutModal
+        isOpen={isLogoutModalOpen}
+        onConfirm={() => {
+          setIsLogoutModalOpen(false);
+          // TODO: 로그아웃 로직 구현
+        }}
+        onCancel={() => setIsLogoutModalOpen(false)}
+      />
     </>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -144,7 +144,7 @@ const Header = () => {
             </div>
           ) : (
             // 내비게이션
-            <ul className="flex w-full max-w-[60.25rem] h-full mr-4 px-[4.281rem] header-white-box text-gray-600 justify-between">
+            <ul className="flex w-full h-full mr-4 px-[4.281rem] header-white-box text-gray-600 justify-between">
               {NAV_ITEMS.map((item) => (
                 <li key={item.label} className="h-full flex items-center tracking-[0.04em]">
                   {item.locked ? (
@@ -165,21 +165,23 @@ const Header = () => {
           )}
 
           {/* 우측 액션 */}
-          <div className="flex max-w-[34.375rem] h-full items-center tracking-[0.04em]">
+          <div className="flex ml-auto max-w-[34.375rem] h-full items-center tracking-[0.04em]">
             {isCodeEditorPage ? (
               <div className="mr-5 h-full w-[10.313rem] header-white-box"></div>
             ) : (
               <>
-                <button className="mr-5 h-full max-w-[11.813rem] header-white-box px-[2.564rem] whitespace-nowrap">
-                  학습 이어하기
-                </button>
-
-                <Link
-                  to={ROUTES.SIGNIN}
-                  className="mr-[1.563rem] w-[8.875rem] max-w-[8.875rem] h-full flex items-center justify-between header-white-box pl-[2.125rem] pr-[1.8rem] whitespace-nowrap"
-                >
-                  로그인 <TfiAngleRight />
-                </Link>
+                {!isLoggedIn ? (
+                  <button className="mr-5 h-full max-w-[11.813rem] header-white-box px-[2.564rem] whitespace-nowrap">
+                    학습 이어하기
+                  </button>
+                ) : (
+                  <Link
+                    to={ROUTES.SIGNIN}
+                    className="mr-[1.563rem] w-[8.875rem] max-w-[8.875rem] h-full flex items-center justify-between header-white-box pl-[2.125rem] pr-[1.8rem] whitespace-nowrap"
+                  >
+                    로그인 <TfiAngleRight />
+                  </Link>
+                )}
               </>
             )}
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -258,6 +258,7 @@ const Header = () => {
           } finally {
             logout();
             setIsLogoutModalOpen(false);
+            navigate(ROUTES.MAIN);
           }
         }}
         onCancel={() => setIsLogoutModalOpen(false)}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,8 @@ import { HiOutlineUser } from 'react-icons/hi';
 import { TfiAngleRight } from 'react-icons/tfi';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 
+import { AnimatePresence, motion } from 'framer-motion';
+
 import { axiosInstance } from '@/api/axios';
 import logo from '@/assets/logo.svg';
 import { NAV_ITEMS } from '@/constants/menuData';
@@ -192,6 +194,7 @@ const Header = () => {
             <div
               className={`relative w-full h-full rounded-4xl ${isCodeEditorPage ? 'max-w-11 max-h-11' : 'max-w-[4.563rem]'}`}
               ref={menuRef}
+              onMouseLeave={() => setIsMenuOpen(false)}
             >
               <button
                 className={`flex items-center justify-center w-full h-full rounded-4xl bg-blue-300 shadow-1 ${isCodeEditorPage ? 'p-3.5' : 'p-[1.594rem]'}`}
@@ -200,36 +203,44 @@ const Header = () => {
                 <AiOutlineMenu className="text-white" />
               </button>
 
-              {isMenuOpen && (
-                <div className="absolute top-12 right-0 bg-white border border-[#ddd] rounded-lg shadow-lg flex flex-col py-2 z-50 min-w-[160px]">
-                  <button
-                    className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                    onClick={handleAccountSettingsClick}
+              <AnimatePresence>
+                {isMenuOpen && (
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.3 }}
+                    className="absolute top-12 right-0 bg-white border border-[#ddd] rounded-lg shadow-lg flex flex-col py-2 z-50 min-w-[160px]"
                   >
-                    계정설정
-                  </button>
-                  <button
-                    className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                    onClick={handleContactClick}
-                  >
-                    문의하기
-                  </button>
-                  <button
-                    className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                    onClick={handleMyPageClick}
-                  >
-                    마이페이지
-                  </button>
-                  {isLoggedIn && (
                     <button
                       className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                      onClick={() => setIsLogoutModalOpen(true)}
+                      onClick={handleAccountSettingsClick}
                     >
-                      로그아웃
+                      계정설정
                     </button>
-                  )}
-                </div>
-              )}
+                    <button
+                      className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
+                      onClick={handleContactClick}
+                    >
+                      문의하기
+                    </button>
+                    <button
+                      className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
+                      onClick={handleMyPageClick}
+                    >
+                      마이페이지
+                    </button>
+                    {isLoggedIn && (
+                      <button
+                        className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
+                        onClick={() => setIsLogoutModalOpen(true)}
+                      >
+                        로그아웃
+                      </button>
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
           </div>
         </nav>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { HiOutlineUser } from 'react-icons/hi';
 import { TfiAngleRight } from 'react-icons/tfi';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 
+import { axiosInstance } from '@/api/axios';
 import logo from '@/assets/logo.svg';
 import { NAV_ITEMS } from '@/constants/menuData';
 import { ROUTES } from '@/constants/routes';
@@ -26,7 +27,7 @@ const Header = () => {
   const codeEditorPathRegex = /^\/workspaces\/[^/]+$/;
   const isCodeEditorPage = codeEditorPathRegex.test(path);
   const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
-  const { isLoggedIn } = useAuthStore();
+  const { isLoggedIn, logout } = useAuthStore();
 
   // 페이지별 상단 여백 높이 설정
   const getTopSpacerHeight = (): string => {
@@ -237,9 +238,27 @@ const Header = () => {
       <LockModal isOpen={isLockModalOpen} onClose={closeLockModal} />
       <LogoutModal
         isOpen={isLogoutModalOpen}
-        onConfirm={() => {
-          setIsLogoutModalOpen(false);
-          // TODO: 로그아웃 로직 구현
+        onConfirm={async () => {
+          try {
+            const token = sessionStorage.getItem('accessToken');
+
+            if (token) {
+              await axiosInstance.post(
+                '/v1/auth/signout',
+                {},
+                {
+                  headers: {
+                    Authorization: `Bearer ${token}`,
+                  },
+                },
+              );
+            }
+          } catch (error) {
+            console.error('로그아웃 요청 실패:', error);
+          } finally {
+            logout();
+            setIsLogoutModalOpen(false);
+          }
         }}
         onCancel={() => setIsLogoutModalOpen(false)}
       />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ import logo from '@/assets/logo.svg';
 import { NAV_ITEMS } from '@/constants/menuData';
 import { ROUTES } from '@/constants/routes';
 import { useLockModal } from '@/hooks/useLockModal';
+import { useAuthStore } from '@/store/authStore';
 
 import LockModal from './LockModal';
 
@@ -23,6 +24,7 @@ const Header = () => {
   const codeEditorPathRegex = /^\/workspaces\/[^/]+$/;
   const isCodeEditorPage = codeEditorPathRegex.test(path);
   const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
+  const { isLoggedIn } = useAuthStore();
 
   // 페이지별 상단 여백 높이 설정
   const getTopSpacerHeight = (): string => {
@@ -215,12 +217,14 @@ const Header = () => {
                   >
                     마이페이지
                   </button>
-                  <button
-                    className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
-                    onClick={() => alert('로그아웃')}
-                  >
-                    로그아웃
-                  </button>
+                  {isLoggedIn && (
+                    <button
+                      className="text-left text-sm px-4 py-2 hover:bg-[#f5f5f5]"
+                      onClick={() => alert('로그아웃')}
+                    >
+                      로그아웃
+                    </button>
+                  )}
                 </div>
               )}
             </div>

--- a/src/components/InfoPanel.tsx
+++ b/src/components/InfoPanel.tsx
@@ -40,7 +40,7 @@ interface LevelItem {
 
 const panelContent: Record<InfoPanelProps['type'], { title: string; desc: DescItem[] }> = {
   fe: {
-    title: `${JOB_TYPES.FE}란?`,
+    title: `${JOB_TYPES.FRONT}란?`,
     desc: [
       {
         icon: WorkstationIcon,
@@ -65,7 +65,7 @@ const panelContent: Record<InfoPanelProps['type'], { title: string; desc: DescIt
     ],
   },
   be: {
-    title: `${JOB_TYPES.BE}란?`,
+    title: `${JOB_TYPES.BACK}란?`,
     desc: [
       {
         icon: SettingsIcon,

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import Header from './Header';
+import Footer from './Footer';
+
+const Layout = () => {
+  return (
+    <>
+      <Header />
+      <main>
+        <Outlet />
+      </main>
+      <Footer />
+    </>
+  );
+};
+
+export default Layout;

--- a/src/components/LogoutModal.tsx
+++ b/src/components/LogoutModal.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+interface LogoutModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const LogoutModal = ({ isOpen, onConfirm, onCancel }: LogoutModalProps) => {
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-modal"
+      onClick={onCancel}
+    >
+      <div
+        className="shadow-10 w-[25rem] bg-white rounded-1.5xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-7 text-base/[1.5] text-center">
+          <p>로그아웃 하시겠습니까?</p>
+        </div>
+        <div className="gap-2 flex justify-center p-3.5">
+          <button
+            type="button"
+            className="rounded-lg px-4 py-1.5 text-sm/[1.16] font-[590] bg-gray-180 text-black"
+            onClick={onCancel}
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            className="rounded-lg px-4 py-1.5 text-sm/[1.16] font-[590] bg-blue-400 text-white"
+            onClick={onConfirm}
+          >
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LogoutModal;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,20 +1,16 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 
 import { ROUTES } from '@/constants/routes';
 import { useAuthStore } from '@/store/authStore';
 
-interface ProtectedRouteProps {
-  children: React.ReactNode;
-}
-
-const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+const ProtectedRoute = () => {
   const { isLoggedIn } = useAuthStore();
 
   if (!isLoggedIn) {
     return <Navigate to={ROUTES.SIGNIN} replace />;
   }
 
-  return <>{children}</>;
+  return <Outlet />;
 };
 
 export default ProtectedRoute;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate } from 'react-router-dom';
+
+import { ROUTES } from '@/constants/routes';
+import { useAuthStore } from '@/store/authStore';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const { isLoggedIn } = useAuthStore();
+
+  if (!isLoggedIn) {
+    return <Navigate to={ROUTES.SIGNIN} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -1,20 +1,16 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 
 import { ROUTES } from '@/constants/routes';
 import { useAuthStore } from '@/store/authStore';
 
-interface PublicRouteProps {
-  children: React.ReactNode;
-}
-
-const PublicRoute = ({ children }: PublicRouteProps) => {
+const PublicRoute = () => {
   const { isLoggedIn } = useAuthStore();
 
   if (isLoggedIn) {
     return <Navigate to={ROUTES.MAIN} replace />;
   }
 
-  return <>{children}</>;
+  return <Outlet />;
 };
 
 export default PublicRoute;

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate } from 'react-router-dom';
+
+import { ROUTES } from '@/constants/routes';
+import { useAuthStore } from '@/store/authStore';
+
+interface PublicRouteProps {
+  children: React.ReactNode;
+}
+
+const PublicRoute = ({ children }: PublicRouteProps) => {
+  const { isLoggedIn } = useAuthStore();
+
+  if (isLoggedIn) {
+    return <Navigate to={ROUTES.MAIN} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PublicRoute;

--- a/src/constants/jobTypes.ts
+++ b/src/constants/jobTypes.ts
@@ -1,6 +1,8 @@
 export const JOB_TYPES = {
-  FE: 'Frontend',
-  BE: 'Backend',
+  FRONT: 'Frontend',
+  BACK: 'Backend',
   DESIGN: 'Designer',
   PLAN: 'Project Manager',
 } as const;
+
+export type JobKey = keyof typeof JOB_TYPES;

--- a/src/pages/CodeEditorPage.tsx
+++ b/src/pages/CodeEditorPage.tsx
@@ -85,7 +85,7 @@ const CodeEditorPage = () => {
   const path = location.pathname;
   const { isLockModalOpen, closeLockModal, handleLockedItemClick } = useLockModal();
 
-  const userRole = JOB_TYPES.FE; // 사용자 직무
+  const userRole = JOB_TYPES.FRONT; // 사용자 직무
   const [activeTab, setActiveTab] = useState<'overview' | 'request' | 'answer'>('overview');
   const [currentRequestIndex, setCurrentRequestIndex] = useState<number>(0); // 직무별 요청사항 현재 인덱스
   const noRequest = path === '/workspaces/team-project-1'; // 1주차는 요청사항 없음
@@ -160,9 +160,9 @@ const CodeEditorPage = () => {
       content:
         '회원가입 시안은 피그마에 있어요. 폰트는 Pretendard, 버튼 색 #0070f3 / hover #005bb5. placeholder는 ‘이름 입력’, ‘이메일 주소 입력’, ‘비밀번호 입력’, ‘비밀번호 확인’. 에러 메시지는 입력창 하단 **빨간색(#FF4D4F)**으로 표시해주세요. 모바일에선 입력창 100% 폭, 버튼 하단 여백 16px.',
     },
-    { role: JOB_TYPES.FE, image: FEDeveloperImg, content: '텍스트를 입력하세요. (요청사항)' },
+    { role: JOB_TYPES.FRONT, image: FEDeveloperImg, content: '텍스트를 입력하세요. (요청사항)' },
     {
-      role: JOB_TYPES.BE,
+      role: JOB_TYPES.BACK,
       image: BEDeveloperImg,
       content:
         '회원가입 API는 **/api/v1/register**로 POST입니다. Body에 name, email, password 주세요. 성공 시 201 Created로 사용자 정보를 JSON으로 반환하고, 토큰은 발급하지 않아요(로그인은 3주차에서 별도 진행). 실패 시 400/409/422/500 등 상태 코드로 내려줄게요.',

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -92,7 +92,7 @@ const CoursesPage = () => {
               selectedTab === 'fe' ? 'bg-[#007bff] text-white' : 'text-[#007bff]'
             }`}
           >
-            {JOB_TYPES.FE}
+            {JOB_TYPES.FRONT}
           </button>
 
           <AnimatePresence>
@@ -120,7 +120,7 @@ const CoursesPage = () => {
               selectedTab === 'be' ? 'bg-[#007bff] text-white' : 'text-[#007bff]'
             }`}
           >
-            {JOB_TYPES.BE}
+            {JOB_TYPES.BACK}
           </button>
 
           <AnimatePresence>

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,0 +1,44 @@
+import { Link, useNavigate } from 'react-router-dom';
+
+import logo from '@/assets/logo.svg';
+import { ROUTES } from '@/constants/routes';
+
+const ErrorPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen text-center">
+      <Link to={ROUTES.MAIN}>
+        <img
+          src={logo}
+          alt="HACKPLAY"
+          className="h-8"
+        />
+      </Link>
+      <img
+        src={`${import.meta.env.BASE_URL}favicon/android-chrome-512x512.png`}
+        alt="아이콘"
+        className="w-26 grayscale brightness-110 mt-11"
+      />
+      <p className="mt-14 mb-2.5 text-gray-600 text-lg/[1.5] tracking-tight">
+        앗! 페이지를 찾을 수 없어요. 🫨
+      </p>
+      <div className="flex gap-0.5 mb-20">
+        <Link
+          to={ROUTES.MAIN}
+          className="flex items-center justify-center w-27 h-10 rounded-2xl border border-gray-250 text-gray-650 text-base/[1.4] tracking-tight"
+        >
+          메인으로
+        </Link>
+        <button
+          onClick={() => navigate(-1)}
+          className="w-27 h-10 rounded-2xl border border-gray-250 text-gray-650 text-base/[1.4] tracking-tight"
+        >
+          이전 페이지
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/pages/FrontIntermediatePage.tsx
+++ b/src/pages/FrontIntermediatePage.tsx
@@ -9,8 +9,8 @@ import { useLockModal } from '@/hooks/useLockModal';
 // 라우트 경로에 따른 포지션 매핑 함수
 const getPositionByRoute = (job?: string): string => {
   const jobToPosition: Record<string, string> = {
-    fe: `${JOB_TYPES.FE} Developer`,
-    be: `${JOB_TYPES.BE} Developer`,
+    fe: `${JOB_TYPES.FRONT} Developer`,
+    be: `${JOB_TYPES.BACK} Developer`,
     design: JOB_TYPES.DESIGN,
   };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -22,8 +22,6 @@ const LoginPage = () => {
     mode: 'onChange',
   });
 
-  const canSubmit = isValid;
-
   const onSubmit: SubmitHandler<FormValues> = async (data) => {
     try {
       const response = await axiosInstance.post('/v1/auth/signin', data);
@@ -104,9 +102,9 @@ const LoginPage = () => {
 
           <button
             type="submit"
-            disabled={!canSubmit}
+            disabled={!isValid}
             className={`bg-[#0066cc] text-white p-[14px] text-[1.1rem] border-none rounded-[8px]
-              ${canSubmit ? 'hover:bg-[#005bb5]' : ''}`}
+              ${isValid ? 'hover:bg-[#005bb5]' : ''}`}
           >
             로그인
           </button>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { axiosInstance } from '@/api/axios';
 import { ROUTES } from '@/constants/routes';
+import { useAuthStore } from '@/store/authStore';
 
 interface FormValues {
   email: string;
@@ -11,6 +12,7 @@ interface FormValues {
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const login = useAuthStore((state) => state.login);
 
   const {
     register,
@@ -28,11 +30,13 @@ const LoginPage = () => {
 
       const result = response.data;
 
-      sessionStorage.setItem('accessToken', result.data.accessToken);
-      localStorage.setItem('nickname', result.data.nickname);
-      localStorage.setItem('email', result.data.email);
-      localStorage.setItem('profileImageUrl', result.data.profileImageUrl);
-      localStorage.setItem('role', result.data.role);
+      login({
+        accessToken: result.data.accessToken,
+        nickname: result.data.nickname,
+        email: result.data.email,
+        profileImageUrl: result.data.profileImageUrl,
+        role: result.data.role,
+      });
 
       navigate(ROUTES.MAIN);
     } catch (error: any) {

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -357,8 +357,8 @@ const SignupPage = () => {
             <option value="">직무 선택</option>
             <option value="PLAN">기획</option>
             <option value="DESIGN">디자인</option>
-            <option value="FRONT">{JOB_TYPES.FE}</option>
-            <option value="BACK">{JOB_TYPES.BE}</option>
+            <option value="FRONT">{JOB_TYPES.FRONT}</option>
+            <option value="BACK">{JOB_TYPES.BACK}</option>
           </select>
           {errors.role && <p className="text-red-500 text-sm mt-1">{errors.role.message}</p>}
 

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom';
 
+import ProtectedRoute from '@/components/ProtectedRoute';
 import { ROUTES } from '@/constants/routes';
 import BasicLearningPage from '@/pages/BasicLearningPage';
 import CodeEditorPage from '@/pages/CodeEditorPage';
@@ -35,7 +36,14 @@ const Router = () => {
       />
 
       {/* 코드 에디터 */}
-      <Route path={ROUTES.WORKSPACE(':lectureId')} element={<CodeEditorPage />} />
+      <Route
+        path={ROUTES.WORKSPACE(':lectureId')}
+        element={
+          <ProtectedRoute>
+            <CodeEditorPage />
+          </ProtectedRoute>
+        }
+      />
 
       {/* 기초 학습 */}
       <Route path={ROUTES.BASIC_LEARNING.ROOT} element={<BasicLearningPage />} />

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -2,10 +2,12 @@ import { Route, Routes } from 'react-router-dom';
 
 import ProtectedRoute from '@/components/ProtectedRoute';
 import PublicRoute from '@/components/PublicRoute';
+import Layout from '@/components/Layout';
 import { ROUTES } from '@/constants/routes';
 import BasicLearningPage from '@/pages/BasicLearningPage';
 import CodeEditorPage from '@/pages/CodeEditorPage';
 import CoursesPage from '@/pages/CoursesPage';
+import ErrorPage from '@/pages/ErrorPage';
 import LectureDetailPage from '@/pages/LectureDetailPage';
 import LectureListPage from '@/pages/LectureListPage';
 import LectureMainPage from '@/pages/LectureMainPage';
@@ -17,41 +19,46 @@ import SignupPage from '@/pages/SignupPage';
 const Router = () => {
   return (
     <Routes>
-      {/* 메인 */}
-      <Route path={ROUTES.MAIN} element={<MainPage />} />
+      {/* 헤더/푸터가 있는 페이지들 */}
+      <Route element={<Layout />}>
+        <Route path={ROUTES.MAIN} element={<MainPage />} />
 
-      {/* Auth */}
-      <Route element={<PublicRoute />}>
-        <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
-        <Route path={ROUTES.SIGNIN} element={<LoginPage />} />
+        {/* Auth */}
+        <Route element={<PublicRoute />}>
+          <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+          <Route path={ROUTES.SIGNIN} element={<LoginPage />} />
+        </Route>
+
+        {/* 단계별 학습 */}
+        <Route path={ROUTES.COURSES.ROOT} element={<CoursesPage />} />
+        <Route path={ROUTES.COURSES.LECTURE_LIST(':job', ':level')} element={<LectureListPage />} />
+        <Route
+          path={ROUTES.COURSES.LECTURE_MAIN(':job', ':level', ':lectureId')}
+          element={<LectureMainPage />}
+        />
+        <Route
+          path={ROUTES.COURSES.LECTURE_DETAIL(':job', ':level', ':lectureId')}
+          element={<LectureDetailPage />}
+        />
+
+        {/* 코드 에디터 */}
+        <Route element={<ProtectedRoute />}>
+          <Route path={ROUTES.WORKSPACE(':lectureId')} element={<CodeEditorPage />} />
+        </Route>
+
+        {/* 기초 학습 */}
+        <Route path={ROUTES.BASIC_LEARNING.ROOT} element={<BasicLearningPage />} />
+        <Route
+          path={ROUTES.BASIC_LEARNING.LECTURE_DETAIL(':lectureId')}
+          element={<LectureDetailPage />}
+        />
+
+        {/* 팀 프로젝트 */}
+        <Route path={ROUTES.PROJECTS} element={<ProjectsPage />} />
       </Route>
 
-      {/* 단계별 학습 */}
-      <Route path={ROUTES.COURSES.ROOT} element={<CoursesPage />} />
-      <Route path={ROUTES.COURSES.LECTURE_LIST(':job', ':level')} element={<LectureListPage />} />
-      <Route
-        path={ROUTES.COURSES.LECTURE_MAIN(':job', ':level', ':lectureId')}
-        element={<LectureMainPage />}
-      />
-      <Route
-        path={ROUTES.COURSES.LECTURE_DETAIL(':job', ':level', ':lectureId')}
-        element={<LectureDetailPage />}
-      />
-
-      {/* 코드 에디터 */}
-      <Route element={<ProtectedRoute />}>
-        <Route path={ROUTES.WORKSPACE(':lectureId')} element={<CodeEditorPage />} />
-      </Route>
-
-      {/* 기초 학습 */}
-      <Route path={ROUTES.BASIC_LEARNING.ROOT} element={<BasicLearningPage />} />
-      <Route
-        path={ROUTES.BASIC_LEARNING.LECTURE_DETAIL(':lectureId')}
-        element={<LectureDetailPage />}
-      />
-
-      {/* 팀 프로젝트 */}
-      <Route path={ROUTES.PROJECTS} element={<ProjectsPage />} />
+      {/* 헤더/푸터가 없는 에러 페이지 */}
+      <Route path="*" element={<ErrorPage />} />
     </Routes>
   );
 };

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
 
 import ProtectedRoute from '@/components/ProtectedRoute';
+import PublicRoute from '@/components/PublicRoute';
 import { ROUTES } from '@/constants/routes';
 import BasicLearningPage from '@/pages/BasicLearningPage';
 import CodeEditorPage from '@/pages/CodeEditorPage';
@@ -20,8 +21,22 @@ const Router = () => {
       <Route path={ROUTES.MAIN} element={<MainPage />} />
 
       {/* Auth */}
-      <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
-      <Route path={ROUTES.SIGNIN} element={<LoginPage />} />
+      <Route
+        path={ROUTES.SIGNUP}
+        element={
+          <PublicRoute>
+            <SignupPage />
+          </PublicRoute>
+        }
+      />
+      <Route
+        path={ROUTES.SIGNIN}
+        element={
+          <PublicRoute>
+            <LoginPage />
+          </PublicRoute>
+        }
+      />
 
       {/* 단계별 학습 */}
       <Route path={ROUTES.COURSES.ROOT} element={<CoursesPage />} />

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -21,22 +21,10 @@ const Router = () => {
       <Route path={ROUTES.MAIN} element={<MainPage />} />
 
       {/* Auth */}
-      <Route
-        path={ROUTES.SIGNUP}
-        element={
-          <PublicRoute>
-            <SignupPage />
-          </PublicRoute>
-        }
-      />
-      <Route
-        path={ROUTES.SIGNIN}
-        element={
-          <PublicRoute>
-            <LoginPage />
-          </PublicRoute>
-        }
-      />
+      <Route element={<PublicRoute />}>
+        <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+        <Route path={ROUTES.SIGNIN} element={<LoginPage />} />
+      </Route>
 
       {/* 단계별 학습 */}
       <Route path={ROUTES.COURSES.ROOT} element={<CoursesPage />} />
@@ -51,14 +39,9 @@ const Router = () => {
       />
 
       {/* 코드 에디터 */}
-      <Route
-        path={ROUTES.WORKSPACE(':lectureId')}
-        element={
-          <ProtectedRoute>
-            <CodeEditorPage />
-          </ProtectedRoute>
-        }
-      />
+      <Route element={<ProtectedRoute />}>
+        <Route path={ROUTES.WORKSPACE(':lectureId')} element={<CodeEditorPage />} />
+      </Route>
 
       {/* 기초 학습 */}
       <Route path={ROUTES.BASIC_LEARNING.ROOT} element={<BasicLearningPage />} />

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand';
+
+import { JobKey } from '@/constants/jobTypes';
+
+interface UserInfo {
+  nickname: string;
+  email: string;
+  role: JobKey;
+  profileImageUrl?: string;
+}
+
+interface AuthState {
+  isLoggedIn: boolean;
+  user: UserInfo | null;
+  login: (data: { accessToken: string } & UserInfo) => void;
+  logout: () => void;
+  hydrate: () => void;
+}
+
+const STORAGE_KEYS = {
+  token: 'accessToken',
+  nickname: 'nickname',
+  email: 'email',
+  profile: 'profileImageUrl',
+  role: 'role',
+};
+
+const hasWindow = typeof window !== 'undefined';
+
+const getStoredAuth = (): { isLoggedIn: boolean; user: UserInfo | null } => {
+  if (!hasWindow) return { isLoggedIn: false, user: null };
+
+  const accessToken = sessionStorage.getItem(STORAGE_KEYS.token);
+
+  if (!accessToken) return { isLoggedIn: false, user: null };
+
+  return {
+    isLoggedIn: true,
+    user: {
+      nickname: localStorage.getItem(STORAGE_KEYS.nickname) ?? '',
+      email: localStorage.getItem(STORAGE_KEYS.email) ?? '',
+      profileImageUrl: localStorage.getItem(STORAGE_KEYS.profile) ?? undefined,
+      role: localStorage.getItem(STORAGE_KEYS.role) as JobKey,
+    },
+  };
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: false,
+  user: null,
+  login: ({ accessToken, nickname, email, profileImageUrl, role }) => {
+    if (!hasWindow) return;
+
+    sessionStorage.setItem(STORAGE_KEYS.token, accessToken);
+    if (nickname) localStorage.setItem(STORAGE_KEYS.nickname, nickname);
+    if (email) localStorage.setItem(STORAGE_KEYS.email, email);
+    if (profileImageUrl) localStorage.setItem(STORAGE_KEYS.profile, profileImageUrl);
+    if (role) localStorage.setItem(STORAGE_KEYS.role, role);
+
+    set({
+      isLoggedIn: true,
+      user: { nickname, email, profileImageUrl, role },
+    });
+  },
+  logout: () => {
+    if (hasWindow) {
+      sessionStorage.removeItem(STORAGE_KEYS.token);
+      localStorage.removeItem(STORAGE_KEYS.nickname);
+      localStorage.removeItem(STORAGE_KEYS.email);
+      localStorage.removeItem(STORAGE_KEYS.profile);
+      localStorage.removeItem(STORAGE_KEYS.role);
+    }
+
+    set({ isLoggedIn: false, user: null });
+  },
+  hydrate: () => {
+    const stored = getStoredAuth();
+    set(stored);
+  },
+}));

--- a/src/styles.css
+++ b/src/styles.css
@@ -49,6 +49,7 @@
   --color-gray-100: #f4f4f4;
   --color-gray-120: #f3f3f3;
   --color-gray-150: #eeeeee;
+  --color-gray-180: #dddddd;
   --color-gray-200: #d9d9d9;
   --color-gray-250: #cfcfcf;
   --color-gray-260: #cacaca;
@@ -77,6 +78,7 @@
   --shadow-7: 1px 1px 20px -9px rgba(0, 0, 0, 0.4);
   --shadow-8: 1px 1px 30px -9px rgba(0, 0, 0, 0.4);
   --shadow-9: 1.455px 1.455px 1.455px rgba(0, 0, 0, 0.1);
+  --shadow-10: 1px 1px 30px -9px rgba(0, 113, 188, 1);
 
   /** z-index 계층 구조 **/
 


### PR DESCRIPTION
## 요약

- Zustand 기반 인증 상태 관리를 도입하고
- 로그아웃 기능 전반(UI, 상태, API, 라우팅 보호)을 구현했습니다.
<br>

## 작업 내용

### 인증 상태 관리
- Zustand를 사용한 전역 인증 스토어 추가
- 앱 마운트 시 `hydrate()`를 호출해 저장된 로그인 상태 복원
- 기존 로그인 상태 관리 로직을 Zustand 기반으로 리팩토링

### 로그아웃 UI / UX
- 비로그인 사용자 인터페이스에서 로그아웃 메뉴 항목 제거
- 로그인 상태에 따라 로그인/로그아웃 버튼 조건부 렌더링
- 로그아웃 클릭 시 “로그아웃 하시겠습니까?” 확인 모달 표시 (SweetAlert2 사용)
- 로그아웃 후 별도 메시지 없이 메인 페이지로 리디렉션

### 로그아웃 로직
- 로그아웃 API 호출 로직 추가
- 클라이언트에서 Access Token 삭제 처리
- Axios 요청 시 토큰을 Authorization 헤더에 자동 포함

### 라우팅 및 접근 제어
- ProtectedRoute / PublicRoute 컴포넌트 추가
- Outlet 기반 구조로 리팩토링
- 로그아웃 이후 보호된 페이지 접근 시 로그인 페이지로 리디렉션
- 로그인 이후 로그인/회원가입 페이지 접근 시 메인 페이지로 리디렉션
- 그 외 정의되지 않은 경로로 접근 시 에러 페이지 표시

### 구조 및 기타 개선
- Header / Footer / Router 구조를 캡슐화한 Layout 컴포넌트 도입
- 에러 페이지 추가
- 드롭다운 UI 개선 (마우스 아웃 시 닫힘, 애니메이션 추가)
- 디자인 변수 추가 및 헤더 여백 조정
- 로그인 상태별 헤더 UI 수정
- 불필요한 변수 제거 및 상수 네이밍(FE/BE → FRONT/BACK) 정리
<br>

## 참고 사항

- 비로그인 시 헤더 및 드롭다운 (학습 이어하기, 로그아웃 버튼 제거)
<img width="700" alt="image" src="https://github.com/user-attachments/assets/6cc2260c-72fd-4de9-b607-e3dfae46d787" />
<img width="100" alt="image" src="https://github.com/user-attachments/assets/f75865f3-7858-4ed5-bb29-92407c3a8d82" />

- 로그인 시 헤더 (로그인 버튼 제거)
<img width="700" alt="image" src="https://github.com/user-attachments/assets/5b727d89-4f0c-4f4c-a2ca-d7edfd962585" />

- 로그아웃 확인 모달
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3ee3e16c-ade6-49f5-abc7-6378223dd769" />

- 에러 페이지
<img width="5757" height="3237" alt="image" src="https://github.com/user-attachments/assets/c125f6a7-655e-4f2b-8fd6-886efcc84bd3" />

- [Zustand](https://zustand-demo.pmnd.rs/)
<br>

## 관련 이슈

- Closes #38 
